### PR TITLE
[Feat] 매장 상세 페이지에 환급 쿠폰도 보여지도록 추가 구현

### DIFF
--- a/MarketPlace/API/Endpoint/CouponEndpoint.swift
+++ b/MarketPlace/API/Endpoint/CouponEndpoint.swift
@@ -22,7 +22,7 @@ enum CouponEndpoint: Endpoint {
     var path: String {
         switch self {
         case .fetchValidCoupon: return "api/coupons"
-        case .fetchValidPaybackCoupon: return "api/coupons/payback-coupons"
+        case .fetchValidPaybackCoupon: return "api/payback-coupons"
         case .fetchTopPoplarCoupon: return "api/coupons/top/popular"
         case .fetchTopLatestCoupon: return "api/coupons/top/latest"
         case .fetchTopClosingCoupon: return "api/coupons/top/closing"

--- a/MarketPlace/API/Endpoint/CouponEndpoint.swift
+++ b/MarketPlace/API/Endpoint/CouponEndpoint.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum CouponEndpoint: Endpoint {
     case fetchValidCoupon(marketId: Int, couponId: Int?, size: Int?)
+    case fetchValidPaybackCoupon(marketId: Int, couponId: Int?, size: Int?)
     case fetchTopPoplarCoupon(pageSize: Int?)
     case fetchTopLatestCoupon(pageSize: Int?)
     case fetchTopClosingCoupon(pageSize: Int?)
@@ -21,6 +22,7 @@ enum CouponEndpoint: Endpoint {
     var path: String {
         switch self {
         case .fetchValidCoupon: return "api/coupons"
+        case .fetchValidPaybackCoupon: return "api/coupons/payback-coupons"
         case .fetchTopPoplarCoupon: return "api/coupons/top/popular"
         case .fetchTopLatestCoupon: return "api/coupons/top/latest"
         case .fetchTopClosingCoupon: return "api/coupons/top/closing"
@@ -90,7 +92,8 @@ enum CouponEndpoint: Endpoint {
             
             return items
             
-        case .fetchValidCoupon(let marketId, let couponId, let size):
+        case .fetchValidCoupon(let marketId, let couponId, let size),
+            .fetchValidPaybackCoupon(let marketId, let couponId, let size):
             var items: [URLQueryItem] = []
             
             items.append(contentsOf: [

--- a/MarketPlace/API/Endpoint/MemberCouponEndpoint.swift
+++ b/MarketPlace/API/Endpoint/MemberCouponEndpoint.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum MemberCouponEndpoint: Endpoint {
     case downloadCoupon(couponId: Int)
+    case downloadPaybackCoupon(couponId: Int)
     case fetchMemberCoupon(type: String, memberCouponId: Int?, size: Int?)
     case useMemberCoupon(memberCouponId: Int)
     case fetchMemeberPaybackCoupon(type: String, memberCouponId: Int?, size: Int?)
@@ -18,6 +19,7 @@ enum MemberCouponEndpoint: Endpoint {
     var path: String {
         switch self {
         case .downloadCoupon(let couponId): return "api/members/coupons/\(couponId)"
+        case .downloadPaybackCoupon(let couponId): return "api/members/payback-coupons/\(couponId)"
         case .fetchMemberCoupon: return "api/members/coupons"
         case .useMemberCoupon: return "api/members/coupons"
         case .fetchMemeberPaybackCoupon: return "api/members/payback-coupons"
@@ -26,7 +28,9 @@ enum MemberCouponEndpoint: Endpoint {
 
     var method: HTTPMethod {
         switch self {
-        case .downloadCoupon: .post
+        case .downloadCoupon,
+            .downloadPaybackCoupon:
+                .post
         case .fetchMemberCoupon,
             .fetchMemeberPaybackCoupon:
                 .get

--- a/MarketPlace/API/Service/NetworkService.swift
+++ b/MarketPlace/API/Service/NetworkService.swift
@@ -69,8 +69,6 @@ final class NetworkService: NetworkServiceProtocol {
         }
         
         print(request.url)
-        print(request.allHTTPHeaderFields)
-        print(request.httpBody)
         
         do {
             

--- a/MarketPlace/Model/CouponModel.swift
+++ b/MarketPlace/Model/CouponModel.swift
@@ -36,8 +36,8 @@ struct CouponValidModel: Codable, Identifiable {
     let couponId: Int
     let couponName: String
     let couponDescription: String
-    let deadLine: String
-    var isAvailable: Bool
+    let deadLine: String?
+    var isAvailable: Bool?
     var isMemberIssued: Bool
     var couponType: String
 

--- a/MarketPlace/Model/CouponModel.swift
+++ b/MarketPlace/Model/CouponModel.swift
@@ -39,6 +39,7 @@ struct CouponValidModel: Codable, Identifiable {
     let deadLine: String
     var isAvailable: Bool
     var isMemberIssued: Bool
+    var couponType: String
 
     var id: Int { couponId }
 }

--- a/MarketPlace/Service/CouponService.swift
+++ b/MarketPlace/Service/CouponService.swift
@@ -11,6 +11,9 @@ protocol CouponServiceProtocol {
     // MARK: - 유효 쿠폰 조회 리스트
     func fetchValidCoupon(marketId: Int, couponId: Int?, size: Int?) async -> NetworkResult<APIResDto<CouponValidResponse>>
     
+    // MARK: - 유효 환급 쿠폰 조회 리스트
+    func fetchValidPaybackCoupon(marketId: Int, couponId: Int?, size: Int?) async -> NetworkResult<APIResDto<CouponValidResponse>>
+    
     // MARK: - 인기 쿠폰 TOP 조회
     func fetchCouponTopPopular(pageSize: Int?) async -> NetworkResult<APIResDto<[CouponTopModel]>>
     
@@ -85,7 +88,7 @@ final class CouponService: CouponServiceProtocol {
         )
     }
     
-    // MARK: - 유효 쿠폰 조회 리스트
+    // MARK: - 유효 쿠폰 조회 API
     func fetchValidCoupon(
         marketId: Int,
         couponId: Int?,
@@ -93,6 +96,20 @@ final class CouponService: CouponServiceProtocol {
     ) async -> NetworkResult<APIResDto<CouponValidResponse>> {
         return await networkService.request(
             CouponEndpoint.fetchValidCoupon(
+                marketId: marketId,
+                couponId: couponId,
+                size: size)
+        )
+    }
+    
+    // MARK: - 유효 환급쿠폰 조회 API
+    func fetchValidPaybackCoupon(
+        marketId: Int,
+        couponId: Int?,
+        size: Int?
+    ) async -> NetworkResult<APIResDto<CouponValidResponse>> {
+        return await networkService.request(
+            CouponEndpoint.fetchValidPaybackCoupon(
                 marketId: marketId,
                 couponId: couponId,
                 size: size)

--- a/MarketPlace/Service/MemberCouponService.swift
+++ b/MarketPlace/Service/MemberCouponService.swift
@@ -11,6 +11,9 @@ protocol MemberCouponServiceProtocol {
     // MARK: - 회원 쿠폰 발급 API
     func downloadCoupon(couponId: Int) async -> NetworkResult<CommonMsgResDTO>
     
+    // MARK: - 회원 환급쿠폰 발급 API
+    func downloadPaybackCoupon(couponId: Int) async -> NetworkResult<CommonMsgResDTO>
+    
     // MARK: - 회원 쿠폰 리스트 API
     func fetchMemberCoupon(type: String, memberCouponId: Int?, size: Int?) async -> NetworkResult<APIResDto<MembersCouponResponse>>
     
@@ -34,6 +37,13 @@ final class MemberCouponService: MemberCouponServiceProtocol {
     func downloadCoupon(couponId: Int) async -> NetworkResult<CommonMsgResDTO> {
         return await networkService.request(
             MemberCouponEndpoint.downloadCoupon(couponId: couponId)
+        )
+    }
+    
+    // MARK: - 회원 환급쿠폰 발급 API
+    func downloadPaybackCoupon(couponId: Int) async -> NetworkResult<CommonMsgResDTO> {
+        return await networkService.request(
+            MemberCouponEndpoint.downloadPaybackCoupon(couponId: couponId)
         )
     }
     

--- a/MarketPlace/View/Main/Components/MarketCouponListView.swift
+++ b/MarketPlace/View/Main/Components/MarketCouponListView.swift
@@ -95,8 +95,6 @@ struct MarketCouponListView: View {
     }
 }
 
-
-
 struct ToastView: View {
     let message: String
     @Binding var isShowing: Bool

--- a/MarketPlace/View/Main/Components/MarketCouponListView.swift
+++ b/MarketPlace/View/Main/Components/MarketCouponListView.swift
@@ -45,27 +45,44 @@ struct MarketCouponListView: View {
                                 .lineLimit(2)
                                 .multilineTextAlignment(.leading)
                                 .frame(maxWidth: 200, alignment: .leading)
-
-                            Text(coupon.deadLine.toKoreanDateFormat())
-                                .pretendardFont(size: 14, weight: .regular)
-                                .foregroundColor(.white)
+                            if let deadline = coupon.deadLine {
+                                Text(deadline.toKoreanDateFormat())
+                                    .pretendardFont(size: 14, weight: .regular)
+                                    .foregroundColor(.white)
+                            } else {
+                                Text("행사 종료시 까지")
+                                    .pretendardFont(size: 14, weight: .regular)
+                                    .foregroundColor(.white)
+                            }
                         }
                         .padding(.leading, 25)
                         .padding(.vertical, 5)
-                        .opacity(coupon.isAvailable ? 1.0 : 0.5)
                     }
                     .padding(.horizontal, 16)
                     .tag(index)
                     .onTapGesture {
-                        if coupon.isAvailable && !coupon.isMemberIssued {
-                            selectedCouponId = coupon.id
-                            isPopupVisible = true
-                        } else if coupon.isMemberIssued {
-                            toastMessage = "이미 발급 완료된 쿠폰입니다"
-                            showToast = true
-                        } else if !coupon.isAvailable {
-                            toastMessage = "기한이 만료되었습니다"
-                            showToast = true
+                        // - CASE: 증정 쿠폰
+                        if let isAvailable = coupon.isAvailable {
+                            if isAvailable && !coupon.isMemberIssued {
+                                selectedCouponId = coupon.id
+                                isPopupVisible = true
+                            } else if coupon.isMemberIssued {
+                                toastMessage = "이미 발급 완료된 쿠폰입니다."
+                                showToast = true
+                            } else if !isAvailable {
+                                toastMessage = "기한이 만료되었습니다."
+                                showToast = true
+                            }
+                        }
+                        // - CASE: 환급 쿠폰
+                        else {
+                            if !coupon.isMemberIssued {
+                                selectedCouponId = coupon.id
+                                isPopupVisible = true
+                            } else {
+                                toastMessage = "이미 발급 완료된 쿠폰입니다."
+                                showToast = true
+                            }
                         }
                     }
                 }

--- a/MarketPlace/View/Main/View/CouponGetPopupView.swift
+++ b/MarketPlace/View/Main/View/CouponGetPopupView.swift
@@ -70,8 +70,18 @@ struct CouponGetPopupView: View {
         coupon.isMemberIssued = true
         isPopupVisible = false
         
-        Task {
-            await viewModel.downloadCoupons(couponId: coupon.couponId)
+        switch coupon.couponType {
+        case "PAYBACK":
+            Task {
+                await viewModel.downloadPaybackCoupons(couponId: coupon.couponId)
+            }
+        case "GIFT":
+            Task {
+                await viewModel.downloadCoupons(couponId: coupon.couponId)
+            }
+            
+        default:
+            break
         }
     }
 }

--- a/MarketPlace/ViewModel/Main/CouponPopupViewModel.swift
+++ b/MarketPlace/ViewModel/Main/CouponPopupViewModel.swift
@@ -29,4 +29,16 @@ final class CouponPopupViewModel: ObservableObject {
             print("[downloadCoupons] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
         }
     }
+    
+    func downloadPaybackCoupons(couponId: Int) async {
+        let result = await memberCouponSerivce.downloadPaybackCoupon(couponId: couponId)
+        
+        switch result {
+        case .success(let data, _):
+            self.message = data.message
+            print(message)
+        case .failure(let statusCode, let message):
+            print("[downloadPaybackCoupons] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
+        }
+    }
 }

--- a/MarketPlace/ViewModel/Main/MarketDetailViewModel.swift
+++ b/MarketPlace/ViewModel/Main/MarketDetailViewModel.swift
@@ -55,7 +55,7 @@ final class MarketDetailViewModel: ObservableObject {
             size: size
         )
         
-        switch (validCoupon, validPaybackCoupon) {
+        switch (validPaybackCoupon, validCoupon) {
         case (.success(let data1, _), .success(let data2, _)):
             self.validCoupons = data1.response.couponResDtos
             self.validCoupons.append(contentsOf: data2.response.couponResDtos)

--- a/MarketPlace/ViewModel/Main/MarketDetailViewModel.swift
+++ b/MarketPlace/ViewModel/Main/MarketDetailViewModel.swift
@@ -43,17 +43,30 @@ final class MarketDetailViewModel: ObservableObject {
         size: Int?
     ) async {
         
-        let result = await couponService.fetchValidCoupon(
+        let validCoupon = await couponService.fetchValidCoupon(
             marketId: marketId,
             couponId: couponId,
             size: size
         )
         
-        switch result {
-        case .success(let data, _):
+        let validPaybackCoupon = await couponService.fetchValidPaybackCoupon(
+            marketId: marketId,
+            couponId: couponId,
+            size: size
+        )
+        
+        switch (validCoupon, validPaybackCoupon) {
+        case (.success(let data1, _), .success(let data2, _)):
+            self.validCoupons = data1.response.couponResDtos
+            self.validCoupons.append(contentsOf: data2.response.couponResDtos)
+        case (.success(let data, _), .failure(let statusCode, let message)):
             self.validCoupons = data.response.couponResDtos
-        case .failure(let statusCode, let message):
-            print("[fetchValidCoupons] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
+            print("[fetchValidPaybackCoupon] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
+        case (.failure(let statusCode, let message), .success(let data, _)):
+            self.validCoupons = data.response.couponResDtos
+            print("[fetchValidCoupon] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
+        default:
+            print("[fetchValidCoupons] - 데이터가 없습니다.")
         }
     }
 }

--- a/MarketPlace/ViewModel/Main/MarketDetailViewModel.swift
+++ b/MarketPlace/ViewModel/Main/MarketDetailViewModel.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@MainActor
 final class MarketDetailViewModel: ObservableObject {
     @Published var marketDetail: MarketDetailModel?
     @Published var errorMessage: String?


### PR DESCRIPTION
## ⭐️ Related Issue
 - #49 

## 📝 Description
- 환급 쿠폰 API 추가
    - CouponEndpoint에 FetchPaybackCoupon 추가
    - CouponService에 FetchPaybackCoupon 추가
    - FetchPaybackCoupon ViewModel에 로직 작성 

- 환급 쿠폰 다운로드 API 추가
   - MemberCouponEndpoint에 다운로드 PaybackCoupon 추가
   - MemberCouponService에 다운로드 PaybackCoupon 추가
   - 환급 쿠폰 다운로드 로직 작성
   - 쿠폰 타입별 다운로드 API 분리


## 📸 Screenshot
|이름|이미지|설명|
| --- | --- | --- |
|가게 상세페이지|<img width="559" height="1062" alt="스크린샷 2025-08-19 15 57 17" src="https://github.com/user-attachments/assets/712160c1-6149-4ce0-9d0a-bd4b76fa77d7" />|매장 상세페이지 쿠폰 리스트에 환급 쿠폰도 보여지도록 수정하였습니다.|


## 📢 Notes
- 증정 쿠폰 다운로드 테스트가 추가적으로 진행되어야함