### PR TITLE
[Feat] 마이쿠폰함의 환급 쿠폰 카테고리 영수증 제출 여부에 따라 구별

### DIFF
--- a/MarketPlace.xcodeproj/project.pbxproj
+++ b/MarketPlace.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		29D87F462DE85AC500CE9011 /* CheerCardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D87F452DE85AC500CE9011 /* CheerCardCellViewModel.swift */; };
 		29D87F4A2DE8629900CE9011 /* CircleCategoryTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D87F492DE8629900CE9011 /* CircleCategoryTabView.swift */; };
 		29D87F832DE86D6900CE9011 /* MemberInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D87F822DE86D6900CE9011 /* MemberInfoModel.swift */; };
+		29DAD79B2E72A6780087CA53 /* CouponCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DAD79A2E72A6780087CA53 /* CouponCategory.swift */; };
 		29E749322DEEA91100E765E0 /* MyCouponCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E749312DEEA91100E765E0 /* MyCouponCellViewModel.swift */; };
 		29E749342DEEABFA00E765E0 /* MyCouponResDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E749332DEEABFA00E765E0 /* MyCouponResDto.swift */; };
 		29E749362DEECFBA00E765E0 /* FavoriteMarketModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E749352DEECFBA00E765E0 /* FavoriteMarketModel.swift */; };
@@ -261,6 +262,7 @@
 		29D87F452DE85AC500CE9011 /* CheerCardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerCardCellViewModel.swift; sourceTree = "<group>"; };
 		29D87F492DE8629900CE9011 /* CircleCategoryTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleCategoryTabView.swift; sourceTree = "<group>"; };
 		29D87F822DE86D6900CE9011 /* MemberInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberInfoModel.swift; sourceTree = "<group>"; };
+		29DAD79A2E72A6780087CA53 /* CouponCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponCategory.swift; sourceTree = "<group>"; };
 		29E749312DEEA91100E765E0 /* MyCouponCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCouponCellViewModel.swift; sourceTree = "<group>"; };
 		29E749332DEEABFA00E765E0 /* MyCouponResDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCouponResDto.swift; sourceTree = "<group>"; };
 		29E749352DEECFBA00E765E0 /* FavoriteMarketModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteMarketModel.swift; sourceTree = "<group>"; };
@@ -537,6 +539,7 @@
 				29B3EBA62E03CE0D0095A310 /* UserDefaultsKeys.swift */,
 				29B3EBA82E03CF800095A310 /* KeyChainKeys.swift */,
 				29B5236E2E150C9300120AE3 /* CouponType.swift */,
+				29DAD79A2E72A6780087CA53 /* CouponCategory.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -1187,6 +1190,7 @@
 				B28889A32D4BC9370040EC3F /* CouponResDtos.swift in Sources */,
 				29B523712E152C0100120AE3 /* UINavigationController+.swift in Sources */,
 				B207A25F2D54B18C0099A8DB /* MyCouponCell.swift in Sources */,
+				29DAD79B2E72A6780087CA53 /* CouponCategory.swift in Sources */,
 				29B5236F2E150C9300120AE3 /* CouponType.swift in Sources */,
 				290A71AD2E026969009AEAF8 /* TopClosingCouponResDto.swift in Sources */,
 				B215F2962DE6D77B00F53C51 /* AlertListView.swift in Sources */,

--- a/MarketPlace/Model/MembersCouponModel.swift
+++ b/MarketPlace/Model/MembersCouponModel.swift
@@ -10,6 +10,7 @@ struct MembersCouponModel: Codable, Identifiable {
     let description: String
     var used: Bool
     let couponType: String
+    let isSubmit: Bool
     let deadLine: String?
     let expired: Bool
     

--- a/MarketPlace/Types/CouponCategory.swift
+++ b/MarketPlace/Types/CouponCategory.swift
@@ -1,0 +1,40 @@
+//
+//  CouponCategory.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 9/11/25.
+//
+
+import Foundation
+
+enum CouponCategory: CaseIterable {
+    case payback, gift, ended
+    
+    static let orderedCases: [CouponCategory] = [
+        .payback, .gift, .ended
+    ]
+
+    init?(index: Int) {
+        switch index {
+        case 0: self = .payback
+        case 1: self = .gift
+        case 2: self = .ended
+        default: return nil
+        }
+    }
+
+    func toString() -> String {
+        switch self {
+        case .payback, .gift: return "ISSUED"
+        case .ended: return "ENDED"
+        }
+    }
+
+    func toUIName() -> String {
+        switch self {
+        case .payback: return "환급형 쿠폰"
+        case .gift: return "증정형 쿠폰"
+        case .ended: return "끝난 쿠폰"
+        }
+    }
+}

--- a/MarketPlace/Types/CouponStatus.swift
+++ b/MarketPlace/Types/CouponStatus.swift
@@ -8,29 +8,15 @@
 import Foundation
 
 enum CouponStatus: String, CaseIterable {
-    case issued, ended
-    
-    init?(index: Int) {
-        switch index {
-        case 0: self = .issued
-        case 1: self = .issued
-        case 2: self = .ended
-        default: return nil
-        }
-    }
-    
-    func toString() -> String {
-        switch self {
-        case .issued: return "ISSUED"
-        case .ended: return "ENDED"
-        }
-    }
+    case beforeSubmitReceipt, beforePayback, beforeUsedCoupon, used, ended
     
     func toUIName() -> String {
         switch self {
-        case .issued: return "사용하러 가기"
-        case .ended: return "사용완료"
+        case .beforeSubmitReceipt: "환급하러 가기"
+        case .beforePayback: "환급이 진행중입니다!"
+        case .beforeUsedCoupon: "사용하러 가기"
+        case .used: "사용 완료"
+        case .ended: "기간 만료"
         }
     }
 }
-

--- a/MarketPlace/Types/CouponStatus.swift
+++ b/MarketPlace/Types/CouponStatus.swift
@@ -13,7 +13,7 @@ enum CouponStatus: String, CaseIterable {
     func toUIName() -> String {
         switch self {
         case .beforeSubmitReceipt: "환급하러 가기"
-        case .beforePayback: "환급이 진행중입니다!"
+        case .beforePayback: "환급 진행 중"
         case .beforeUsedCoupon: "사용하러 가기"
         case .used: "사용 완료"
         case .ended: "기간 만료"

--- a/MarketPlace/View/MyPage/Components/CouponCategoryView.swift
+++ b/MarketPlace/View/MyPage/Components/CouponCategoryView.swift
@@ -2,17 +2,16 @@ import SwiftUI
 
 struct CouponCategoryView: View {
     @Binding var selectedCategory: Int
-    private let categories: [String] = ["환급형 쿠폰", "증정형 쿠폰", "끝난 쿠폰"]
     
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
-                ForEach(Array(categories.enumerated()), id: \.offset) { index, category in
+                ForEach(Array(CouponCategory.orderedCases.enumerated()), id: \.offset) { index, category in
                     Button(action: {
                         selectedCategory = index
                     }) {
                         VStack(spacing: 5) {
-                            Text(category)
+                            Text(category.toUIName())
                                 .pretendardFont(size: 14, weight: .semibold)
                                 .foregroundColor(selectedCategory == index ? .black : Color(hex: "#A0A0A0"))
                                 .padding(.bottom, 9)

--- a/MarketPlace/View/MyPage/Components/MyCouponCell.swift
+++ b/MarketPlace/View/MyPage/Components/MyCouponCell.swift
@@ -50,13 +50,13 @@ struct MyCouponCell: View {
                         }
                     }, label: {
                         Text(viewModel.couponStatusText)
-                            .foregroundStyle(viewModel.couponStatus==CouponStatus.issued ? .white : Color(hex: "#727272"))
+                            .foregroundStyle(viewModel.couponStatus==CouponStatus.beforeSubmitReceipt || viewModel.couponStatus==CouponStatus.beforeUsedCoupon ? .white : Color(hex: "#727272"))
                             .pretendardFont(size: 14, weight: .semibold)
                             .padding(.vertical, 15)
                             .frame(maxWidth: .infinity)
                             .background(
                                 RoundedRectangle(cornerRadius: 4)
-                                    .fill(viewModel.couponStatus==CouponStatus.issued ? Color(hex: "#303030") : Color(hex: "#E0E0E0"))
+                                    .fill(viewModel.couponStatus==CouponStatus.beforeSubmitReceipt || viewModel.couponStatus==CouponStatus.beforeUsedCoupon ? Color(hex: "#303030") : Color(hex: "#E0E0E0"))
                             )
                     })
                     .padding(.horizontal ,20)

--- a/MarketPlace/View/MyPage/View/MyCouponView.swift
+++ b/MarketPlace/View/MyPage/View/MyCouponView.swift
@@ -59,14 +59,14 @@ struct MyCouponView: View {
         .navigationBarBackButtonHidden(true)
         .onAppear {
             Task {
-                await viewModel.fetchMemberPaybackCoupon(type: CouponStatus(index: 0)?.toString() ?? "", memberCouponId: nil, size: nil)
+                await viewModel.fetchMemberPaybackCoupon(type: CouponCategory(index: selectedCategoryIndex)?.toString() ?? "", memberCouponId: nil, size: nil)
             }
         }
         .onChange(of: selectedCategoryIndex) {
             Task {
                 switch selectedCategoryIndex {
-                case 0: await viewModel.fetchMemberPaybackCoupon(type: CouponStatus(index: 0)?.toString() ?? "", memberCouponId: nil, size: nil)
-                case 1: await viewModel.fetchMemberCoupon(type: CouponStatus(index: 0)?.toString() ?? "", memberCouponId: nil, size: nil)
+                case 0: await viewModel.fetchMemberPaybackCoupon(type: CouponCategory(index: selectedCategoryIndex)?.toString() ?? "", memberCouponId: nil, size: nil)
+                case 1: await viewModel.fetchMemberCoupon(type: CouponCategory(index: selectedCategoryIndex)?.toString() ?? "", memberCouponId: nil, size: nil)
                 case 2: await viewModel.fetchEndedCoupon()
                 default:
                     break
@@ -80,7 +80,16 @@ struct MyCouponView: View {
     
     // MARK: - coupon Cell 생성
     private func makeCouponCell(for coupon: MembersCouponModel) -> some View {
-        let status = CouponStatus(index: selectedCategoryIndex) ?? .issued
+        var status: CouponStatus = .used
+        
+        if coupon.used { status = .used }
+        else if coupon.expired { status = .ended }
+        else {
+            if coupon.couponType == "GIFT" { status = .beforeUsedCoupon }
+            else if coupon.isSubmit { status = .beforePayback }
+            else { status = .beforeSubmitReceipt }
+        }
+        
         let viewModel = MyCouponCellViewModel(coupon: coupon, couponStatus: status)
         
         return MyCouponCell(viewModel: viewModel) {

--- a/MarketPlace/ViewModel/MyPage/MyCouponCellViewModel.swift
+++ b/MarketPlace/ViewModel/MyPage/MyCouponCellViewModel.swift
@@ -25,14 +25,7 @@ final class MyCouponCellViewModel: ObservableObject {
     }
     
     var couponStatusText: String {
-        switch couponStatus {
-        case .issued:
-            return "사용하러 가기"
-        case .ended:
-            return "사용 완료"
-//        case .expired:
-//            return "기간 만료"
-        }
+        return couponStatus.toUIName()
     }
 
     var formattedDeadline: String {
@@ -44,7 +37,7 @@ final class MyCouponCellViewModel: ObservableObject {
     }
 
     var canUse: Bool {
-        return couponStatus == .issued
+        return couponStatus == .beforeSubmitReceipt || couponStatus == .beforeUsedCoupon
     }
     
     func useMemberCoupon(memberCouponId: Int) async {


### PR DESCRIPTION
## ⭐️ Related Issue
 - #75 

## 📝 Description
마이쿠폰함의 환급 쿠폰 카테고리의 쿠폰 버튼을 영수증 제출 여부에 따라 구별되도록 구현하였습니다. 
추가적으로 `CouponStatus` 열거형으로 구분했던 쿠폰 카테고리 부분을 디자인 변경에 따라  `CouponCategory` 열거형을 새로  추가하여 나누어 구현했습니다. 
<br>

- 기존에는 마이쿠폰함의 디자인이 쿠폰 사용 여부에 따라 구별되면 되었기 때문에 `CouponStatus`로 카테고리와 쿠폰 상태를 나타낼때 함께 사용할 수 있었지만 현재는 표현해야할 쿠폰 상태가 늘어나고, 카테고리와 명확하게 차별점이 생겨 구분하게 되었습니다. 

- 쿠폰 상태는 총 5가지입니다.
   - 환급쿠폰 영수증 제출 전
   - 환급쿠폰 환급 전(영수증은 제출 완료)
   - 증정 쿠폰 사용 전
   - 사용 완료
   - 기간 만료

## 📸 Screenshot
|이름|이미지|설명|
| --- | --- | --- |
|환급 쿠폰 카테고리|<img width="448" height="845" alt="스크린샷 2025-09-12 17 00 08" src="https://github.com/user-attachments/assets/daff2cb7-1b82-4c47-ac2b-22f84df67f0b" />| - |
|증정 쿠폰 카테고리|<img width="448" height="845" alt="스크린샷 2025-09-12 17 01 37" src="https://github.com/user-attachments/assets/15ed2a09-0642-4981-ba47-bab215a1a6e1" />| - | 
|끝난 쿠폰 카테고리|<img width="448" height="845" alt="스크린샷 2025-09-12 17 01 43" src="https://github.com/user-attachments/assets/dd08e0f1-ceda-4283-b058-069ebea1cb82" />| - |


## 📢 Notes
- ~~환급쿠폰 환급 전(영수증 제출은 완료)은 디자인이 없어서 전달 드리고, 임시로 "환급이 진행중입니다" 로 해뒀습니다~~