### PR TITLE
[Refactor] Main, CategoryDetail ViewModel과 View 역할을 명확하게 분리되도록 리팩토링합니다

### DIFF
--- a/MarketPlace/View/Main/View/CategoryDetailView.swift
+++ b/MarketPlace/View/Main/View/CategoryDetailView.swift
@@ -9,50 +9,75 @@ struct CategoryDetailView: View {
             // MARK: - Category 목록 상단 TabView
             CategoryTabView(selectedTab: $selectedTab)
             
-            ScrollView {
-                LazyVStack(spacing: 16) {
-                    ForEach(Array(viewModel.markets.enumerated()), id: \.offset) { index, shop in
-                        NavigationLink(destination: MarketDetailView(marketId: shop.marketId, isBookmarked: shop.isFavorite)) {
-                            VStack {
-                                MarketInfoCell(
-                                    isBookmarked: shop.isFavorite,
-                                    viewModel: MarketInfoCellViewModel(marketData: shop)
-                                )
-                                
-                                Divider()
-                                    .background(Color.gray.opacity(0.5))
-                                    .padding(.horizontal, -20)
+            switch viewModel.state {
+            case .idle:
+                VStack {
+                    Text("")
+                        .foregroundStyle(.gray)
+                        .padding(.top, 40)
+                    
+                    Spacer()
+                }
+            case .empty:
+                VStack {
+                    Text("\(Category(index: selectedTab)?.toUIName() ?? "") 카테고리 매장이 없습니다!")
+                        .foregroundStyle(.gray)
+                        .padding(.top, 40)
+                    
+                    Spacer()
+                }
+            case .loading:
+                VStack {
+                    ProgressView("매장을 불러오는 중입니다!")
+                        .foregroundStyle(.gray)
+                        .padding(.top, 40)
+                    
+                    Spacer()
+                }
+            case .loaded(let markets, let hasNext):
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        ForEach(Array(markets.enumerated()), id: \.offset) { index, shop in
+                            NavigationLink(destination: MarketDetailView(marketId: shop.marketId, isBookmarked: shop.isFavorite)) {
+                                VStack {
+                                    MarketInfoCell(
+                                        isBookmarked: shop.isFavorite,
+                                        viewModel: MarketInfoCellViewModel(marketData: shop)
+                                    )
+                                    
+                                    Divider()
+                                        .background(Color.gray.opacity(0.5))
+                                        .padding(.horizontal, -20)
+                                }
                             }
-                        }
-                        .onAppear {
-                            guard index == viewModel.markets.count - 1,
-                                  let lastId = viewModel.lastMarketId
-                            else { return }
-                                                        
-                            viewModel.currentCategory = Category(index: selectedTab)?.toString()
-                            
-                            Task {
-                                await viewModel.fetchMarkets(lastPageIndex: lastId, category: Category(index: selectedTab)?.toString() ?? nil)
+                            .onAppear {
+                                if index == markets.count-1, hasNext {
+                                    viewModel.action(.loadNextPage)
+                                }
                             }
                         }
                     }
                 }
+            case .error(let message):
+                VStack {
+                    Text("문제가 발생했습니다!")
+                        .foregroundColor(.gray)
+                        .padding(.top, 40)
+                    
+                    Text(message)
+                        .foregroundColor(.gray)
+                    
+                    Spacer()
+                }
             }
         }
-        .navigationTitle(Category(index: selectedTab)?.toUIName() ?? "")
-        
         /// - NOTE: 이전화면에서 넘어왔을 시 해당 탭의 데이터 불러오기
         .onAppear {
-            Task {
-                await viewModel.fetchMarkets(category: Category(index: selectedTab)?.toString() ?? nil)
-            }
+            viewModel.action(.fetchMarkets(category: Category(index: selectedTab)?.toString()))
         }
         /// - NOTE: 탭 눌렀을 시 해당 탭의 데이터 불러오기
         .onChange(of: selectedTab) {
-            Task {
-                await viewModel.fetchMarkets(category: Category(index: selectedTab)?.toString() ?? nil)
-                viewModel.currentCategory = Category(index: selectedTab)?.toString()
-            }
+            viewModel.action(.fetchMarkets(category: Category(index: selectedTab)?.toString()))
         }
         .toolbar {
             ToolbarItem(placement: .principal) {

--- a/MarketPlace/View/Main/View/MainView.swift
+++ b/MarketPlace/View/Main/View/MainView.swift
@@ -42,9 +42,9 @@ struct MainView: View {
                 }
             }
             .onAppear {
-                viewModel.action(.fetchCouponTopClosing(pageSize: nil))
-                viewModel.action(.fetchCouponTopLatest(pageSize: nil))
-                viewModel.action(.fetchCouponTopPopular(pageSize: nil))
+                viewModel.action(.fetchClosing(pageSize: nil))
+                viewModel.action(.fetchLatest(pageSize: nil))
+                viewModel.action(.fetchPopular(pageSize: nil))
             }
             .navigationDestination(item: $selectedCategoryIndex) { index in
                 CategoryDetailView(selectedTab: $selectedTab)

--- a/MarketPlace/View/Main/View/MainView.swift
+++ b/MarketPlace/View/Main/View/MainView.swift
@@ -14,7 +14,7 @@ struct MainView: View {
                 ScrollView {
                     VStack {
                         // MARK: - 메인 화면 배너
-                        MainBannerView(closingCouponList: $viewModel.couponClosing)
+                        MainBannerView(closingCouponList: $viewModel.state.couponClosing)
             
                         // MARK: - 메인화면 카테고리 버튼 
                         MainCategoryView(
@@ -30,11 +30,11 @@ struct MainView: View {
                             .frame(height: 8)
                         
                         // MARK: - Top 20 인기 멤버십
-                        Top20View(popularCoupons: $viewModel.couponPopular)
+                        Top20View(popularCoupons: $viewModel.state.couponPopular)
                             .padding(.top, 40)
                         
                         // MARK: - 신규 멤버십
-                        NewEventView(latestCoupons: $viewModel.couponLatest)
+                        NewEventView(latestCoupons: $viewModel.state.couponLatest)
                             .padding(.top, 40)
                             .padding(.bottom, 100)
                     }
@@ -42,11 +42,9 @@ struct MainView: View {
                 }
             }
             .onAppear {
-                Task {
-                    await viewModel.fetchCouponTopLatest(pageSize: nil)
-                    await viewModel.fetchCouponTopPopular(pageSize: nil)
-                    await viewModel.fetchCouponTopClosing(pageSize: nil)
-                }
+                viewModel.action(.fetchCouponTopClosing(pageSize: nil))
+                viewModel.action(.fetchCouponTopLatest(pageSize: nil))
+                viewModel.action(.fetchCouponTopPopular(pageSize: nil))
             }
             .navigationDestination(item: $selectedCategoryIndex) { index in
                 CategoryDetailView(selectedTab: $selectedTab)
@@ -55,8 +53,4 @@ struct MainView: View {
             .edgesIgnoringSafeArea(.bottom)
         }
     }
-}
-
-#Preview {
-    MainView()
 }

--- a/MarketPlace/ViewModel/Main/MainViewModel.swift
+++ b/MarketPlace/ViewModel/Main/MainViewModel.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 final class MainViewModel: ViewModelable {
-    // MARK: Types
+    // MARK: - Types
     enum Action {
-        case fetchCouponTopPopular(pageSize: Int?)
-        case fetchCouponTopLatest(pageSize: Int?)
-        case fetchCouponTopClosing(pageSize: Int?)
+        case fetchPopular(pageSize: Int?)
+        case fetchLatest(pageSize: Int?)
+        case fetchClosing(pageSize: Int?)
     }
     
     struct State {
@@ -21,7 +21,7 @@ final class MainViewModel: ViewModelable {
         var couponClosing: [TopClosingCouponResDto] = []
     }
       
-    // MARK: Properties
+    // MARK: - Properties
     @Published var state: State
     
     private var couponService: CouponServiceProtocol
@@ -32,14 +32,14 @@ final class MainViewModel: ViewModelable {
         state = State()
     }
     
-    // MARK: Action
+    // MARK: - Action
     func action(_ action: Action) {
         switch action {
-        case .fetchCouponTopPopular(let pageSize):
+        case .fetchPopular(let pageSize):
             Task { await fetchCouponTopPopular(pageSize: pageSize) }
-        case .fetchCouponTopLatest(let pageSize):
+        case .fetchLatest(let pageSize):
             Task { await fetchCouponTopLatest(pageSize: pageSize) }
-        case .fetchCouponTopClosing(let pageSize):
+        case .fetchClosing(let pageSize):
             Task { await fetchCouponTopClosing(pageSize: pageSize) }
         }
     }

--- a/MarketPlace/ViewModel/Main/MainViewModel.swift
+++ b/MarketPlace/ViewModel/Main/MainViewModel.swift
@@ -7,49 +7,74 @@
 
 import Foundation
 
-final class MainViewModel: ObservableObject {
-    @Published var couponPopular: [CouponTopModel] = []
-    @Published var couponLatest: [CouponTopModel] = []
-    @Published var couponClosing: [TopClosingCouponResDto] = []
+final class MainViewModel: ViewModelable {
+    // MARK: Types
+    enum Action {
+        case fetchCouponTopPopular(pageSize: Int?)
+        case fetchCouponTopLatest(pageSize: Int?)
+        case fetchCouponTopClosing(pageSize: Int?)
+    }
+    
+    struct State {
+        var couponPopular: [CouponTopModel] = []
+        var couponLatest: [CouponTopModel] = []
+        var couponClosing: [TopClosingCouponResDto] = []
+    }
+      
+    // MARK: Properties
+    @Published var state: State
     
     private var couponService: CouponServiceProtocol
     
+    // MARK: Initailizer
     init(couponService: CouponServiceProtocol = CouponService()) {
         self.couponService = couponService
+        state = State()
+    }
+    
+    // MARK: Action
+    func action(_ action: Action) {
+        switch action {
+        case .fetchCouponTopPopular(let pageSize):
+            Task { await fetchCouponTopPopular(pageSize: pageSize) }
+        case .fetchCouponTopLatest(let pageSize):
+            Task { await fetchCouponTopLatest(pageSize: pageSize) }
+        case .fetchCouponTopClosing(let pageSize):
+            Task { await fetchCouponTopClosing(pageSize: pageSize) }
+        }
     }
     
     // MARK: - 인기 쿠폰 조회
-    func fetchCouponTopPopular(pageSize: Int?) async {
+    private func fetchCouponTopPopular(pageSize: Int?) async {
         let result = await couponService.fetchCouponTopPopular(pageSize: pageSize)
         
         switch result {
         case .success(let data, _):
-            self.couponPopular = data.response
+            state.couponPopular = data.response
         case .failure(let statusCode, let message):
             print("[fetchCouponTopPopular] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
         }
     }
     
     // MARK: - 최신 쿠폰 조회
-    func fetchCouponTopLatest(pageSize: Int?) async {
+    private func fetchCouponTopLatest(pageSize: Int?) async {
         let result = await couponService.fetchCouponTopLatest(pageSize: pageSize)
         
         switch result {
         case .success(let data, _):
-            self.couponLatest = data.response
+            state.couponLatest = data.response
         case .failure(let statusCode, let message):
             print("[fetchCouponTopLatest] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
         }
     }
     
     // MARK: - 마감임박 쿠폰 조회
-    func fetchCouponTopClosing(pageSize: Int?) async {
+    private func fetchCouponTopClosing(pageSize: Int?) async {
         let result = await couponService.fetchCouponTopClosing(pageSize: pageSize)
-        print(result)
 
         switch result {
         case .success(let data, _):
-            self.couponClosing = data.response
+            state.couponClosing = data.response
         case .failure(let statusCode, let message):
             print("[fetchCouponTopClosing] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
         }

--- a/MarketPlace/ViewModel/Main/MainViewModel.swift
+++ b/MarketPlace/ViewModel/Main/MainViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@MainActor
 final class MainViewModel: ViewModelable {
     // MARK: - Types
     enum Action {
@@ -26,7 +27,7 @@ final class MainViewModel: ViewModelable {
     
     private var couponService: CouponServiceProtocol
     
-    // MARK: Initailizer
+    // MARK: Initializer
     init(couponService: CouponServiceProtocol = CouponService()) {
         self.couponService = couponService
         state = State()

--- a/MarketPlace/ViewModel/Main/MarketCategoryDetailViewModel.swift
+++ b/MarketPlace/ViewModel/Main/MarketCategoryDetailViewModel.swift
@@ -3,24 +3,42 @@
 import Foundation
 
 @MainActor
-class MarketCategoryDetailViewModel: ObservableObject {
+class MarketCategoryDetailViewModel: ViewModelable {
+    // MARK: - Types
+    enum Action {
+        case fetchMarkets
+    }
+    
+    struct State {
+        var markets: [MarketModel] = []
+    }
+    
+    // MARK: - Properties
+    @Published var state: State
+    
+    
     @Published var markets: [MarketModel] = []
     @Published var isLoading: Bool = false
     @Published var hasNextPage: Bool = true
     @Published var lastMarketId: Int?
     @Published var currentCategory: String?
     
-    var currentPage: Int = 1
-    
+    private var currentPage: Int = 1
     private var marketService: MarketServiceProtocol
     
+
     init(
         marketService: MarketServiceProtocol = MarketService()
     ) {
         self.marketService = marketService
+        state = State()
     }
     
-    func fetchMarkets(
+    func action(_ action: Action) {
+        
+    }
+    
+    private func fetchMarkets(
         lastPageIndex: Int? = nil,
         category: String? = nil,
         pageSize: Int? = nil

--- a/MarketPlace/ViewModel/Main/MarketCategoryDetailViewModel.swift
+++ b/MarketPlace/ViewModel/Main/MarketCategoryDetailViewModel.swift
@@ -2,81 +2,86 @@
 
 import Foundation
 
-@MainActor
-class MarketCategoryDetailViewModel: ViewModelable {
+final class MarketCategoryDetailViewModel: ViewModelable {
     // MARK: - Types
     enum Action {
-        case fetchMarkets
+        case fetchMarkets(category: String?)
+        case loadNextPage
     }
     
-    struct State {
-        var markets: [MarketModel] = []
+    enum State {
+        case idle
+        case empty
+        case loading                     /// 현재 안쓰이고 있음
+        case loaded([MarketModel], hasNext: Bool)
+        case error(String)
     }
     
     // MARK: - Properties
-    @Published var state: State
+    @Published private(set) var state: State = .idle
     
-    
-    @Published var markets: [MarketModel] = []
-    @Published var isLoading: Bool = false
-    @Published var hasNextPage: Bool = true
-    @Published var lastMarketId: Int?
-    @Published var currentCategory: String?
-    
+    private var lastMarketId: Int?
     private var currentPage: Int = 1
+    private var hasNextPage: Bool = true
+    private var currentCategory: String?
     private var marketService: MarketServiceProtocol
-    
 
     init(
         marketService: MarketServiceProtocol = MarketService()
     ) {
         self.marketService = marketService
-        state = State()
     }
     
     func action(_ action: Action) {
-        
+        switch action {
+        case .fetchMarkets(let category):
+            Task { await fetchMarkets(category: category, reset: true) }
+        case .loadNextPage:
+            Task { await fetchMarkets(reset: false) }
+        }
     }
     
     private func fetchMarkets(
-        lastPageIndex: Int? = nil,
         category: String? = nil,
-        pageSize: Int? = nil
+        reset: Bool
     ) async {
-        if currentCategory != category {
+        
+        if reset || currentCategory != category {
             currentPage = 1
-            hasNextPage = true
+            lastMarketId = nil
         }
         
-        guard !isLoading, hasNextPage else { return }
-        
-        isLoading = true
+        currentCategory = category
         
         let result = await marketService.fetchMarketAll(
-                lastPageIndex: lastPageIndex,
+                lastPageIndex: lastMarketId,
                 category: category,
-                pageSize: pageSize
+                pageSize: 10
         )
-        
+                
         switch result {
         case .success(let data, _):
-            if currentPage == 1 {
-                self.markets = data.response.marketResDtos
+            let markets = data.response.marketResDtos
+            
+            if markets.isEmpty && currentPage == 1 {
+                self.state = .empty
+                return
+            }
+            
+            if currentPage > 1  {
+                if case .loaded(let existing, _) = state {
+                    let combined = existing + markets
+                    self.state = .loaded(combined, hasNext: data.response.hasNext)
+                }
             } else {
-                self.markets.append(contentsOf: data.response.marketResDtos)
+                self.state = .loaded(markets, hasNext: data.response.hasNext)
             }
-            
-            if let last = data.response.marketResDtos.last {
-                self.lastMarketId = last.marketId
-            }
-            
-            self.hasNextPage = data.response.hasNext
+                        
+            lastMarketId = markets.last?.id
             currentPage += 1
             
         case .failure(let code, let message):
-            print("[fetchMarkets] - [\(code)]: \(message ?? "알 수 없는 오류")")
+            self.state = .error("[\(code)] \(message ?? "알 수 없는 오류")")
         }
-            
-        isLoading = false
     }
 }

--- a/MarketPlace/ViewModelable.swift
+++ b/MarketPlace/ViewModelable.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@MainActor
 protocol ViewModelable: ObservableObject {
   associatedtype Action
   associatedtype State


### PR DESCRIPTION
## ⭐️ Related Issue
 - #86 

## 📝 Description
Main과 CategoryDetail의 View와 ViewModel의 역할을 명확하게 분리합니다.
각 ViewModel이 ViewModelable을 채택하도록 변경합니다.
<br>


## 📢 Notes
- ViewModel의 상태중 loading 케이스는 현재 사용되지않고 있음. (지금 구조에서 적용하게되면 계속 loading 상태에 머무르는 문제있음.. )
   - 문제해결해서 다음 PR에서 같이 올릴 예정..!