### PR TITLE
[Hotfix] 마감임박 매장 DTO 수정 및 반영 

### DIFF
--- a/MarketPlace.xcodeproj/project.pbxproj
+++ b/MarketPlace.xcodeproj/project.pbxproj
@@ -823,7 +823,6 @@
 				B2C399022CA145CC004800DD /* Preview Content */,
 				29BF18AF2DE4492C00836D7E /* API_URL.plist */,
 				B2F85BE62D6FAB210011DDF3 /* LocationManager.swift */,
-				293DCF182DE6CDE2000122C5 /* KakaoMapKey.xcconfig */,
 				295948BA2E8E198100F641DC /* ViewModelable.swift */,
 			);
 			path = MarketPlace;
@@ -1367,7 +1366,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"MarketPlace/Preview Content\"";
-				DEVELOPMENT_TEAM = 7RR74CRWQW;
+				DEVELOPMENT_TEAM = F7GYZYWC6V;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MarketPlace/Info.plist;
@@ -1406,7 +1405,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MarketPlace/Preview Content\"";
-				DEVELOPMENT_TEAM = 7RR74CRWQW;
+				DEVELOPMENT_TEAM = F7GYZYWC6V;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MarketPlace/Info.plist;

--- a/MarketPlace/DTO/TopClosingCouponResDto.swift
+++ b/MarketPlace/DTO/TopClosingCouponResDto.swift
@@ -10,32 +10,35 @@ import Foundation
 struct TopClosingCouponResDto: Codable, Identifiable {
     let couponId: Int
     let couponName: String
-    let deadline: String
+    let deadline: String?
     let marketId: Int
     let marketName: String
     let thumbnail: String
     
     var id: Int { couponId }
     
-    var deadlineKoreanFormat: String {
-        // 출력 포맷 함수
+    var deadlineKoreanFormat: String? {
+        /// 출력 포맷 함수
         func formatDate(_ date: Date) -> String {
             let outputFormatter = DateFormatter()
             outputFormatter.locale = Locale(identifier: "ko_KR")
             outputFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-            outputFormatter.dateFormat = "yyyy년 MM월 dd일"
-            return outputFormatter.string(from: date) + "까지"
+            outputFormatter.dateFormat = "yyyy년 MM월 dd일"
+            return outputFormatter.string(from: date) + "까지"
         }
 
-        // 1) ISO8601DateFormatter (micro/milli seconds 지원)
+        /// 1) ISO8601DateFormatter (micro/milli seconds 지원)
         let iso = ISO8601DateFormatter()
         iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        
+        guard let deadline = deadline else { return nil }
+        
         if let d = iso.date(from: deadline) {
             return formatDate(d)
         }
 
-        // 1a) 서버가 timezone 표기를 빼고 보내는 경우(예: "2025-12-20T09:55:00.976")
-        //     이 경우 UTC로 가정하고 'Z'를 붙여 파싱 시도해본다.
+        /// 1a) 서버가 timezone 표기를 빼고 보내는 경우(예: "2025-12-20T09:55:00.976")
+        ///     이 경우 UTC로 가정하고 'Z'를 붙여 파싱 시도해본다.
         if !deadline.contains("Z"),
            deadline.range(of: #"([+-]\d{2}:\d{2}|[+-]\d{4})"#, options: .regularExpression) == nil {
             let withZ = deadline + "Z"
@@ -44,7 +47,7 @@ struct TopClosingCouponResDto: Codable, Identifiable {
             }
         }
 
-        // 2) DateFormatter 폴백: 자주 쓰이는 포맷들을 순서대로 시도
+        /// 2) DateFormatter 폴백: 자주 쓰이는 포맷들을 순서대로 시도
         let fallbackFormats = [
             "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
             "yyyy-MM-dd'T'HH:mm:ss.SSS",
@@ -55,14 +58,14 @@ struct TopClosingCouponResDto: Codable, Identifiable {
         for fmt in fallbackFormats {
             let df = DateFormatter()
             df.locale = Locale(identifier: "en_US_POSIX")
-            df.timeZone = TimeZone(secondsFromGMT: 0) // 서버가 UTC라고 가정
+            df.timeZone = TimeZone(secondsFromGMT: 0) // 서버가 UTC라고 가정
             df.dateFormat = fmt
             if let d = df.date(from: deadline) {
                 return formatDate(d)
             }
         }
 
-        // 모두 실패하면 원본 문자열 반환 (for 안정성)
+        /// 모두 실패하면 원본 문자열 반환 (for 안정성)
         return deadline
     }
 }

--- a/MarketPlace/View/Main/Components/ImageTextOverlay.swift
+++ b/MarketPlace/View/Main/Components/ImageTextOverlay.swift
@@ -19,7 +19,7 @@ struct ImageTextOverlay: View {
                 ForEach(texts.indices, id: \.self) { index in
                     Text(texts[index])
                         .foregroundColor(Color.white)
-                        .pretendardFont(size: index == 0 || index == 2 ? 18 : 26, weight: .semibold)
+                        .pretendardFont(size: index == 0 || index == 2 ? 18 : 26, weight: index == 0 || index == 2 ? .semibold : .heavy)
                         .lineLimit(index == 1 ? 2 : 1)
                         .lineSpacing(index == 0 || index == 1 ? 33.8 : 3.12)
                         .padding(.leading, 5)

--- a/MarketPlace/View/Main/Components/MainBannerView.swift
+++ b/MarketPlace/View/Main/Components/MainBannerView.swift
@@ -22,9 +22,8 @@ struct MainBannerView: View {
                             imageName: coupon.thumbnail,
                             texts: [
                                 coupon.marketName,
-                                coupon.couponName,
-                                coupon.deadlineKoreanFormat
-                            ]
+                                coupon.couponName
+                            ] + (coupon.deadlineKoreanFormat != nil ? [coupon.deadlineKoreanFormat!] : [])
                         )
                         .padding(.horizontal, 20)
                         .tag(index)

--- a/MarketPlace/View/Main/Components/NewEventView.swift
+++ b/MarketPlace/View/Main/Components/NewEventView.swift
@@ -3,11 +3,12 @@ import SwiftUI
 
 struct NewEventView: View {
     @Binding var latestCoupons: [CouponTopModel]
+    var currentMonth: String
 
     var body: some View {
         VStack {
             HStack {
-                Text("1월 신규 | 멤버십 혜택")
+                Text("\(currentMonth) 신규 | 멤버십 혜택")
                     .pretendardFont(size: 19, weight: .bold)
                     .foregroundColor(.black)
                 Spacer()

--- a/MarketPlace/View/Main/View/MainView.swift
+++ b/MarketPlace/View/Main/View/MainView.swift
@@ -34,7 +34,7 @@ struct MainView: View {
                             .padding(.top, 40)
                         
                         // MARK: - 신규 멤버십
-                        NewEventView(latestCoupons: $viewModel.couponLatest)
+                        NewEventView(latestCoupons: $viewModel.couponLatest, currentMonth: viewModel.currentMonth)
                             .padding(.top, 40)
                             .padding(.bottom, 100)
                     }

--- a/MarketPlace/ViewModel/Main/MainViewModel.swift
+++ b/MarketPlace/ViewModel/Main/MainViewModel.swift
@@ -18,6 +18,13 @@ final class MainViewModel: ObservableObject {
         self.couponService = couponService
     }
     
+    var currentMonth: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "M월"
+        return formatter.string(from: Date())
+    }
+    
     // MARK: - 인기 쿠폰 조회
     func fetchCouponTopPopular(pageSize: Int?) async {
         let result = await couponService.fetchCouponTopPopular(pageSize: pageSize)

--- a/MarketPlace/ViewModel/Main/MainViewModel.swift
+++ b/MarketPlace/ViewModel/Main/MainViewModel.swift
@@ -45,8 +45,7 @@ final class MainViewModel: ObservableObject {
     // MARK: - 마감임박 쿠폰 조회
     func fetchCouponTopClosing(pageSize: Int?) async {
         let result = await couponService.fetchCouponTopClosing(pageSize: pageSize)
-        print(result)
-
+        
         switch result {
         case .success(let data, _):
             self.couponClosing = data.response


### PR DESCRIPTION
## ⭐️ Related Issue
 - #92

## 📝 Description
- 마감 임박 매장 DTO를 서버와 동일하게 변경 (deadLine의 타입변경)
- 환급 쿠폰일 때는 deadline이 존재하지 않기 때문에 배너에 날짜가 뜨지 않도록 변경하였음
- 메인 뷰 아래 "O월 신규 쿠폰" 텍스트를 매월 변경되도록 수정
<br>


## 📢 Notes
