### PR TITLE
[Hotfix] 카카오맵 Pin 관련 오류 및 URL Scheme 문제 해결

### DIFF
--- a/MarketPlace.xcodeproj/project.pbxproj
+++ b/MarketPlace.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		29CA0F232E5484B100EB4890 /* MarketInfoCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CA0F222E5484B100EB4890 /* MarketInfoCellViewModel.swift */; };
 		29CC3F292E6819E5008F79F6 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CC3F282E6819E5008F79F6 /* UIImage+.swift */; };
 		29CC3F2B2E681ECD008F79F6 /* KakaoMapPoi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CC3F2A2E681ECD008F79F6 /* KakaoMapPoi.swift */; };
+		29CF81A22EBC60920065AE9A /* KakaoMapPoiWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29CF81A12EBC60920065AE9A /* KakaoMapPoiWrapper.swift */; };
+		29D11E362EC3390D001CEA92 /* KakaoAPIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D11E352EC3390D001CEA92 /* KakaoAPIEndpoint.swift */; };
 		29D19D1C2E13CC2000DEEADD /* KakaoMarketDataResDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D19D1B2E13CC2000DEEADD /* KakaoMarketDataResDto.swift */; };
 		29D19D202E13E63B00DEEADD /* RequestMarketMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D19D1F2E13E63B00DEEADD /* RequestMarketMapView.swift */; };
 		29D19D2D2E14234900DEEADD /* RequestMarketMapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D19D2C2E14234900DEEADD /* RequestMarketMapViewModel.swift */; };
@@ -252,6 +254,8 @@
 		29CA0F222E5484B100EB4890 /* MarketInfoCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketInfoCellViewModel.swift; sourceTree = "<group>"; };
 		29CC3F282E6819E5008F79F6 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		29CC3F2A2E681ECD008F79F6 /* KakaoMapPoi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMapPoi.swift; sourceTree = "<group>"; };
+		29CF81A12EBC60920065AE9A /* KakaoMapPoiWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMapPoiWrapper.swift; sourceTree = "<group>"; };
+		29D11E352EC3390D001CEA92 /* KakaoAPIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoAPIEndpoint.swift; sourceTree = "<group>"; };
 		29D19D1B2E13CC2000DEEADD /* KakaoMarketDataResDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMarketDataResDto.swift; sourceTree = "<group>"; };
 		29D19D1F2E13E63B00DEEADD /* RequestMarketMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMarketMapView.swift; sourceTree = "<group>"; };
 		29D19D2C2E14234900DEEADD /* RequestMarketMapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMarketMapViewModel.swift; sourceTree = "<group>"; };
@@ -445,6 +449,7 @@
 				29D53BF62DE8412E008E4F2E /* CheerMarketEndpoint.swift */,
 				2941F76F2DE5A0350063CEFE /* CouponEndpoint.swift */,
 				B26F4E8A2E57308F00C39C37 /* NotificationEndpoint.swift */,
+				29D11E352EC3390D001CEA92 /* KakaoAPIEndpoint.swift */,
 			);
 			path = Endpoint;
 			sourceTree = "<group>";
@@ -725,6 +730,7 @@
 				2976FA2A2DFC4D2F009782D1 /* CouponTopModel.swift */,
 				B24272602E26537F00E3B0ED /* ReceiptModel.swift */,
 				29CC3F2A2E681ECD008F79F6 /* KakaoMapPoi.swift */,
+				29CF81A12EBC60920065AE9A /* KakaoMapPoiWrapper.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1109,6 +1115,7 @@
 				B27E56D52D704438000D2881 /* HotCheerCardCell.swift in Sources */,
 				2941F7932DE5A2FD0063CEFE /* MemberCouponService.swift in Sources */,
 				B215F2942DE61D9600F53C51 /* AlertButtonView.swift in Sources */,
+				29CF81A22EBC60920065AE9A /* KakaoMapPoiWrapper.swift in Sources */,
 				B2122E3D2D6F7C0000BD37F8 /* MarketResDtos.swift in Sources */,
 				29D19D202E13E63B00DEEADD /* RequestMarketMapView.swift in Sources */,
 				29D19D2D2E14234900DEEADD /* RequestMarketMapViewModel.swift in Sources */,
@@ -1125,6 +1132,7 @@
 				B28A22AD2D64F1C000E86EF6 /* StoreSearchButton.swift in Sources */,
 				2941F78D2DE5A28A0063CEFE /* CouponService.swift in Sources */,
 				B21F3CF82D267AF900B83B34 /* MainView.swift in Sources */,
+				29D11E362EC3390D001CEA92 /* KakaoAPIEndpoint.swift in Sources */,
 				2941F7972DE5AAB50063CEFE /* NewEventViewModel.swift in Sources */,
 				B21F3CF62D267AF900B83B34 /* Top20View.swift in Sources */,
 				29B3EBBE2E03DABD0095A310 /* Font+.swift in Sources */,

--- a/MarketPlace.xcodeproj/project.pbxproj
+++ b/MarketPlace.xcodeproj/project.pbxproj
@@ -16,9 +16,7 @@
 		290D93522DE57CDE008AC190 /* CouponInfoCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290D93512DE57CDE008AC190 /* CouponInfoCellViewModel.swift */; };
 		290D93542DE58418008AC190 /* CouponBasicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290D93532DE58418008AC190 /* CouponBasicModel.swift */; };
 		293DCF142DE6CD2E000122C5 /* KakaoMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 293DCF132DE6CD2E000122C5 /* KakaoMapView.swift */; };
-		293DCF172DE6CD89000122C5 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		293DCF442DE6FE43000122C5 /* Array+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 293DCF432DE6FE43000122C5 /* Array+.swift */; };
-		293DCF472DE72B9E000122C5 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		293DCF4D2DE7449F000122C5 /* KakaoMapsSDK-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 293DCF4C2DE7449F000122C5 /* KakaoMapsSDK-SPM */; };
 		2941F76C2DE596590063CEFE /* SearchMarketViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2941F76B2DE596590063CEFE /* SearchMarketViewModel.swift */; };
 		2941F76E2DE597280063CEFE /* MarketSearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2941F76D2DE597280063CEFE /* MarketSearchModel.swift */; };
@@ -68,6 +66,7 @@
 		29B5236F2E150C9300120AE3 /* CouponType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B5236E2E150C9300120AE3 /* CouponType.swift */; };
 		29B523712E152C0100120AE3 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B523702E152C0100120AE3 /* UINavigationController+.swift */; };
 		29B523732E152E0400120AE3 /* MyFavoriteMarketListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B523722E152E0400120AE3 /* MyFavoriteMarketListViewModel.swift */; };
+		29B6EA7D2EB8929D002E71E6 /* KakaoMapKey.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */; };
 		29BF18B02DE4492C00836D7E /* API_URL.plist in Resources */ = {isa = PBXBuildFile; fileRef = 29BF18AF2DE4492C00836D7E /* API_URL.plist */; };
 		29BF18BF2DE45B3900836D7E /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29BF18BE2DE45B3900836D7E /* Category.swift */; };
 		29BF18C12DE4950700836D7E /* APIResDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29BF18C02DE4950700836D7E /* APIResDto.swift */; };
@@ -244,6 +243,7 @@
 		29B5236E2E150C9300120AE3 /* CouponType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponType.swift; sourceTree = "<group>"; };
 		29B523702E152C0100120AE3 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		29B523722E152E0400120AE3 /* MyFavoriteMarketListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFavoriteMarketListViewModel.swift; sourceTree = "<group>"; };
+		29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = KakaoMapKey.xcconfig; sourceTree = "<group>"; };
 		29BF18AF2DE4492C00836D7E /* API_URL.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = API_URL.plist; sourceTree = "<group>"; };
 		29BF18BE2DE45B3900836D7E /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		29BF18C02DE4950700836D7E /* APIResDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResDto.swift; sourceTree = "<group>"; };
@@ -355,8 +355,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				293DCF472DE72B9E000122C5 /* (null) in Frameworks */,
-				293DCF172DE6CD89000122C5 /* (null) in Frameworks */,
 				296CF4192DE806070000F200 /* FirebaseMessaging in Frameworks */,
 				293DCF4D2DE7449F000122C5 /* KakaoMapsSDK-SPM in Frameworks */,
 				296CF4162DE805EB0000F200 /* KakaoMapsSDK-SPM in Frameworks */,
@@ -805,6 +803,7 @@
 		B2C398FB2CA145CB004800DD /* MarketPlace */ = {
 			isa = PBXGroup;
 			children = (
+				29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */,
 				296085B62E1B88C9009CE38B /* ConvertAddress.swift */,
 				29B3EBAA2E03D8CF0095A310 /* Font */,
 				2976FA272DFC4507009782D1 /* Types */,
@@ -823,7 +822,6 @@
 				B2C399022CA145CC004800DD /* Preview Content */,
 				29BF18AF2DE4492C00836D7E /* API_URL.plist */,
 				B2F85BE62D6FAB210011DDF3 /* LocationManager.swift */,
-				293DCF182DE6CDE2000122C5 /* KakaoMapKey.xcconfig */,
 				295948BA2E8E198100F641DC /* ViewModelable.swift */,
 			);
 			path = MarketPlace;
@@ -1031,6 +1029,7 @@
 				29B3EBB72E03D94E0095A310 /* Pretendard-ExtraLight.otf in Resources */,
 				29B3EBB82E03D94E0095A310 /* Pretendard-Regular.otf in Resources */,
 				29B3EBB92E03D94E0095A310 /* Pretendard-Black.otf in Resources */,
+				29B6EA7D2EB8929D002E71E6 /* KakaoMapKey.xcconfig in Resources */,
 				29B3EBBA2E03D94E0095A310 /* Pretendard-Medium.otf in Resources */,
 				29B3EBBB2E03D94E0095A310 /* Pretendard-ExtraBold.otf in Resources */,
 				29B3EBBC2E03D94E0095A310 /* Pretendard-Light.otf in Resources */,
@@ -1240,6 +1239,7 @@
 /* Begin XCBuildConfiguration section */
 		B2C3991B2CA145CC004800DD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -1303,6 +1303,7 @@
 		};
 		B2C3991C2CA145CC004800DD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -1359,6 +1360,7 @@
 		};
 		B2C3991E2CA145CC004800DD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1367,7 +1369,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"MarketPlace/Preview Content\"";
-				DEVELOPMENT_TEAM = 7RR74CRWQW;
+				DEVELOPMENT_TEAM = F7GYZYWC6V;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MarketPlace/Info.plist;
@@ -1399,6 +1401,7 @@
 		};
 		B2C3991F2CA145CC004800DD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1406,7 +1409,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MarketPlace/Preview Content\"";
-				DEVELOPMENT_TEAM = 7RR74CRWQW;
+				DEVELOPMENT_TEAM = F7GYZYWC6V;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MarketPlace/Info.plist;
@@ -1438,6 +1441,7 @@
 		};
 		B2C399212CA145CC004800DD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1457,6 +1461,7 @@
 		};
 		B2C399222CA145CC004800DD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1476,6 +1481,7 @@
 		};
 		B2C399242CA145CC004800DD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1493,6 +1499,7 @@
 		};
 		B2C399252CA145CC004800DD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 29B6EA7C2EB8929D002E71E6 /* KakaoMapKey.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/MarketPlace/API/Endpoint/KakaoAPIEndpoint.swift
+++ b/MarketPlace/API/Endpoint/KakaoAPIEndpoint.swift
@@ -1,0 +1,45 @@
+//
+//  KakaoAPIEndpoint.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 11/11/25.
+//
+
+import Foundation
+
+enum KakaoAPIEndpoint: Endpoint {
+    case searchKakaoMarketKeyword(keyword: String)
+    case convertAddressToPositionWithKakaoAPI(address: String)
+    
+    var baseURL: URL {
+        return URL(string: "https://dapi.kakao.com/v2/local/search") ?? URLManager.shared.baseURL
+    }
+
+    var path: String {
+        switch self {
+        case .searchKakaoMarketKeyword: return "/keyword.json"
+        case .convertAddressToPositionWithKakaoAPI: return "/address.json"
+        }
+    }
+
+    var method: HTTPMethod {
+       return .get
+    }
+
+    var headers: [String : String]? { ["Content-Type": "application/json"] }
+
+    var body: Data? { nil }
+    
+    var queryItems: [URLQueryItem]? {
+        switch self {
+        case .searchKakaoMarketKeyword(let keyword):
+            var items: [URLQueryItem] = []
+            items.append(URLQueryItem(name: "query", value: keyword))
+            items.append(URLQueryItem(name: "category_group_code", value: "FD6"))
+            return items
+            
+        case.convertAddressToPositionWithKakaoAPI(let address):
+            return [URLQueryItem(name: "query", value: address)]
+        }
+    }
+}

--- a/MarketPlace/API/Endpoint/KakaoAPIEndpoint.swift
+++ b/MarketPlace/API/Endpoint/KakaoAPIEndpoint.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 enum KakaoAPIEndpoint: Endpoint {
-    case searchKakaoMarketKeyword(keyword: String)
-    case convertAddressToPositionWithKakaoAPI(address: String)
+    case searchKakaoMarketKeyword(keyword: String, x: String, y: String)
+    case convertAddressToPositionWithKakaoAPI(marketName: String)
     
     var baseURL: URL {
         return URL(string: "https://dapi.kakao.com/v2/local/search") ?? URLManager.shared.baseURL
@@ -17,8 +17,8 @@ enum KakaoAPIEndpoint: Endpoint {
 
     var path: String {
         switch self {
-        case .searchKakaoMarketKeyword: return "/keyword.json"
-        case .convertAddressToPositionWithKakaoAPI: return "/address.json"
+        case .searchKakaoMarketKeyword, 
+                .convertAddressToPositionWithKakaoAPI: return "/keyword.json"
         }
     }
 
@@ -32,14 +32,17 @@ enum KakaoAPIEndpoint: Endpoint {
     
     var queryItems: [URLQueryItem]? {
         switch self {
-        case .searchKakaoMarketKeyword(let keyword):
+        case .searchKakaoMarketKeyword(let keyword, let x, let y):
             var items: [URLQueryItem] = []
             items.append(URLQueryItem(name: "query", value: keyword))
-            items.append(URLQueryItem(name: "category_group_code", value: "FD6"))
+            items.append(URLQueryItem(name: "x", value: x))
+            items.append(URLQueryItem(name: "y", value: y))
+            items.append(URLQueryItem(name: "sorting", value: "distance"))
             return items
             
-        case.convertAddressToPositionWithKakaoAPI(let address):
-            return [URLQueryItem(name: "query", value: address)]
+        case.convertAddressToPositionWithKakaoAPI(let marketName):
+            return [URLQueryItem(name: "query", value: marketName)]
+
         }
     }
 }

--- a/MarketPlace/API/Endpoint/MarketEndpoint.swift
+++ b/MarketPlace/API/Endpoint/MarketEndpoint.swift
@@ -15,15 +15,9 @@ enum MarketEndpoint: Endpoint {
     case postFavoriteMarket(marketId: Int)
     case postMarketRequest(name: String, address: String)
     case fetchMarketsWithAddress(lastPageIndex: Int?, category: String?, pageSize: Int?, address: String="인천광역시 연수구")
-    case searchKakaoMarketKeyword(keyword: String)
     
     var baseURL: URL {
-        switch self {
-        case .searchKakaoMarketKeyword:
-            return URL(string: "https://dapi.kakao.com/v2/local/search") ?? URLManager.shared.baseURL
-        default:
-            return URLManager.shared.baseURL
-        }
+        return URLManager.shared.baseURL
     }
 
     var path: String {
@@ -35,7 +29,6 @@ enum MarketEndpoint: Endpoint {
         case .fetchMarketsWithAddress: return "api/markets/map"
         case .postFavoriteMarket: return "api/favorites"
         case .postMarketRequest: return "api/request-markets"
-        case .searchKakaoMarketKeyword: return "/keyword.json"
         }
     }
 
@@ -110,13 +103,6 @@ enum MarketEndpoint: Endpoint {
                 pageSize.map { URLQueryItem(name: "pageSize", value: String($0)) },
                 URLQueryItem(name: "address", value: address)
             ].compactMap { $0 })
-            
-            return items
-            
-        case .searchKakaoMarketKeyword(let keyword):
-            var items: [URLQueryItem] = []
-            items.append(URLQueryItem(name: "query", value: keyword))
-            items.append(URLQueryItem(name: "category_group_code", value: "FD6"))
             
             return items
         

--- a/MarketPlace/API/Service/NetworkService.swift
+++ b/MarketPlace/API/Service/NetworkService.swift
@@ -17,12 +17,12 @@ enum HTTPMethod: String {
 
 protocol NetworkServiceProtocol {
     func request<T: Decodable>(_ endpoint: Endpoint) async -> NetworkResult<T>
-    func requestFindMarketAPI<T: Decodable>(_ endpoint: Endpoint) async -> NetworkResult<T>
+    func requestKakaoAPI<T: Decodable>(_ endpoint: Endpoint) async -> NetworkResult<T>
 }
 
 final class NetworkService: NetworkServiceProtocol {
     // MARK: - 카카오 키워드 검색 API를 위한 request 메서드
-    func requestFindMarketAPI<T>(_ endpoint: any Endpoint) async -> NetworkResult<T> where T : Decodable {
+    func requestKakaoAPI<T>(_ endpoint: any Endpoint) async -> NetworkResult<T> where T : Decodable {
         var request = endpoint.urlRequest
         
         if let token = Bundle.main.infoDictionary?["KAKAO_API_TOKEN"] as? String {
@@ -59,8 +59,6 @@ final class NetworkService: NetworkServiceProtocol {
     func request<T: Decodable>(_ endpoint: Endpoint) async -> NetworkResult<T>  {
         var request = endpoint.urlRequest
         
-        print(request)
-
         if let token = KeychainManager.getToken() {
             request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         } else {

--- a/MarketPlace/ConvertAddress.swift
+++ b/MarketPlace/ConvertAddress.swift
@@ -27,7 +27,6 @@ final class ConvertAddress {
     func getCoordinateFromRoadAddress(from address: String) async throws -> CLLocationCoordinate2D {
         let geoCoder = CLGeocoder()
         let preprocessAddress = extractBaseRoadAddress(address)
-        print("getCoordinateFromRoadAddress \(preprocessAddress)")
         let places = try await geoCoder.geocodeAddressString(preprocessAddress)
         guard let place = places.last,
               let coordinate = place.location?.coordinate else { throw AddressError.failedToConvertAddress }

--- a/MarketPlace/ConvertAddress.swift
+++ b/MarketPlace/ConvertAddress.swift
@@ -26,7 +26,9 @@ final class ConvertAddress {
     /// - NOTE: 도로명 주소 -> 좌표
     func getCoordinateFromRoadAddress(from address: String) async throws -> CLLocationCoordinate2D {
         let geoCoder = CLGeocoder()
-        let places = try await geoCoder.geocodeAddressString(address)
+        let preprocessAddress = extractBaseRoadAddress(address)
+        print("getCoordinateFromRoadAddress \(preprocessAddress)")
+        let places = try await geoCoder.geocodeAddressString(preprocessAddress)
         guard let place = places.last,
               let coordinate = place.location?.coordinate else { throw AddressError.failedToConvertAddress }
         return coordinate
@@ -42,9 +44,25 @@ final class ConvertAddress {
             throw AddressError.failedToConvertAddress
         }
 
-//        let latitude = Double(coordinate.latitude)
-//        let longitude = String(coordinate.longitude)
-
         return (coordinate.latitude, coordinate.longitude)
+    }
+}
+
+extension ConvertAddress {
+    private func extractBaseRoadAddress(_ address: String) -> String {
+        let pattern = #"([가-힣A-Za-z0-9\s]+(로|길)\s?\d+(-\d+)?)"#
+
+        /// 패턴에 맞게 도로명 주소만 반환
+        if let match = address.range(of: pattern, options: .regularExpression) {
+            return String(address[match]).trimmingCharacters(in: .whitespaces)
+        } else {
+            /// 도로명 주소 패턴이 아닐 경우
+            let fallbackPattern = #"([가-힣A-Za-z]+(시|도)\s?[가-힣A-Za-z]+(구|군))"#
+            if let match = address.range(of: fallbackPattern, options: .regularExpression) {
+                return String(address[match]).trimmingCharacters(in: .whitespaces)
+            } else {
+                return address.trimmingCharacters(in: .whitespaces)
+            }
+        }
     }
 }

--- a/MarketPlace/ConvertAddress.swift
+++ b/MarketPlace/ConvertAddress.swift
@@ -34,16 +34,20 @@ final class ConvertAddress {
     }
     
     /// - NOTE: 도로명 주소 -> 좌표(string)
-    func getPositionFromRoadAddress(from address: String) async throws -> (latitude: Double, longitude: Double) {
+    func getPositionFromRoadAddress(from address: String) async throws -> (latitude: Double?, longitude: Double?) {
         let geoCoder = CLGeocoder()
-        let places = try await geoCoder.geocodeAddressString(address)
         
-        guard let place = places.last,
-              let coordinate = place.location?.coordinate else {
-            throw AddressError.failedToConvertAddress
+        do {
+            let places = try await geoCoder.geocodeAddressString(address)
+            
+            if let place = places.last, let coordinate = place.location?.coordinate {
+                return (coordinate.latitude, coordinate.longitude)
+            } else {
+                return (nil, nil)
+            }
+        } catch {
+            return (nil, nil)
         }
-
-        return (coordinate.latitude, coordinate.longitude)
     }
 }
 

--- a/MarketPlace/DTO/KakaoMarketDataResDto.swift
+++ b/MarketPlace/DTO/KakaoMarketDataResDto.swift
@@ -7,14 +7,19 @@
 
 import Foundation
 
-struct KakaoMarketsDataResDto: Decodable {
-    let documents: [KakaoMarketData]
+struct KakaoMarketsDataResDto<T: Decodable>: Decodable {
+    let documents: [T]
 }
 
 struct KakaoMarketData: Decodable, Identifiable {
     let id: String
     let place_name: String
     let road_address_name: String
+    let x: String
+    let y: String
+}
+
+struct KakaoConvertPositionData: Decodable {
     let x: String
     let y: String
 }

--- a/MarketPlace/Extension/View+.swift
+++ b/MarketPlace/Extension/View+.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 extension View {
+    /// TextField에서 editing 종료 시 호출
     func endTextEditing() {
         UIApplication.shared.sendAction(
             #selector(UIResponder.resignFirstResponder),
@@ -17,7 +18,29 @@ extension View {
         )
     }
     
+    /// pretendard 커스텀 폰트 설정 메서드
     func pretendardFont(size: CGFloat, weight: Font.Weight) -> some View {
         self.font(.pretendard(size, weight: weight))
+    }
+    
+    /// 특정 모서리에 cornerRadius를 설정할 수 있는 메서드
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape(RoundedCorner(radius: radius, corners: corners))
+    }
+}
+
+/// 특정 모서리에 cornerRadius 적용하는 메서드
+///
+/// - Parameters:
+///     - CGFloat: radius 값
+///     - UIRectCorner:  radius 적용할 모서리
+///
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
     }
 }

--- a/MarketPlace/Model/KakaoMapPoi.swift
+++ b/MarketPlace/Model/KakaoMapPoi.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 
-struct KakaoMapPoi {
+struct KakaoMapPoi: Equatable {
     var latitude: Double
     var longitude: Double
     var title: String
+    var id: Int
 }

--- a/MarketPlace/Model/KakaoMapPoiWrapper.swift
+++ b/MarketPlace/Model/KakaoMapPoiWrapper.swift
@@ -1,0 +1,16 @@
+//
+//  KakaoMapPoiWrapper.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 11/6/25.
+//
+
+import Foundation
+
+final class KakaoMapPoiWrapper {
+    let poi: KakaoMapPoi
+    
+    init(_ poi: KakaoMapPoi) {
+        self.poi = poi
+    }
+}

--- a/MarketPlace/Service/MarketService.swift
+++ b/MarketPlace/Service/MarketService.swift
@@ -9,20 +9,13 @@ import Foundation
 
 protocol MarketServiceProtocol {
     // MARK: - 검색 매장 조회 API
-    func fetchSearchMarketsList(
-        lastPageIndex: Int?,
-        pageSize: Int?,
-        name: String
-    ) async -> NetworkResult<APIResDto<MarketResDto<MarketSearchModel>>>
+    func fetchSearchMarketsList(lastPageIndex: Int?, pageSize: Int?, name: String) async -> NetworkResult<APIResDto<MarketResDto<MarketSearchModel>>>
     
     // MARK: - 매장 상세 조회 API
     func fetchMarketDetail(marketId: Int) async -> NetworkResult<APIResDto<MarketDetailModel>>
     
     // MARK: - 전체/카테고리 매장 조회 API
-    func fetchMarketAll(lastPageIndex: Int?,
-                        category: String?,
-                        pageSize: Int?
-    ) async ->  NetworkResult<APIResDto<MarketResDto<MarketModel>>>
+    func fetchMarketAll(lastPageIndex: Int?, category: String?, pageSize: Int?) async ->  NetworkResult<APIResDto<MarketResDto<MarketModel>>>
     
     // MARK: - 매장 찜하기 API
     func postFavoriteMarket(marketId: Int) async -> NetworkResult<CommonMsgResDTO>
@@ -36,8 +29,11 @@ protocol MarketServiceProtocol {
     // MARK: - 주소별 매장 조회 API
     func fetchMarketsWithAddress(lastPageIndex: Int?, category: String?, pageSize: Int?) async -> NetworkResult<APIResDto<MarketResDto<MarketModel>>>
     
-    // MARK: - 카카오 API를 통해 키워드로 매장 정보 받아오기 API
-    func searchKakaoMarketKeyword(keyword: String) async -> NetworkResult<KakaoMarketsDataResDto>
+    // MARK: - 키워드로 매장 정보 받아오기 API (KAKAO API)
+    func searchKakaoMarketKeyword(keyword: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoMarketData>>
+    
+    // MARK: - 매장 주소를 위도, 경도로 변환하기 API (KAKAO API)
+    func convertAddressToPosition(address: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoConvertPositionData>>
 }
 
 
@@ -111,7 +107,12 @@ final class MarketService: MarketServiceProtocol {
     }
     
     // MARK: - 카카오 API를 통해 키워드로 매장 정보 받아오기 API
-    func searchKakaoMarketKeyword(keyword: String) async -> NetworkResult<KakaoMarketsDataResDto> {
-        return await networkService.requestFindMarketAPI(MarketEndpoint.searchKakaoMarketKeyword(keyword: keyword))
+    func searchKakaoMarketKeyword(keyword: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoMarketData>> {
+        return await networkService.requestKakaoAPI(KakaoAPIEndpoint.searchKakaoMarketKeyword(keyword: keyword))
+    }
+    
+    // MARK: - 매장 주소를 위도, 경도로 변환하기 API (KAKAO API)
+    func convertAddressToPosition(address: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoConvertPositionData>> {
+        return await networkService.requestKakaoAPI(KakaoAPIEndpoint.convertAddressToPositionWithKakaoAPI(address: address))
     }
 }

--- a/MarketPlace/Service/MarketService.swift
+++ b/MarketPlace/Service/MarketService.swift
@@ -30,10 +30,10 @@ protocol MarketServiceProtocol {
     func fetchMarketsWithAddress(lastPageIndex: Int?, category: String?, pageSize: Int?) async -> NetworkResult<APIResDto<MarketResDto<MarketModel>>>
     
     // MARK: - 키워드로 매장 정보 받아오기 API (KAKAO API)
-    func searchKakaoMarketKeyword(keyword: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoMarketData>>
+    func searchKakaoMarketKeyword(keyword: String, x: String, y: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoMarketData>>
     
     // MARK: - 매장 주소를 위도, 경도로 변환하기 API (KAKAO API)
-    func convertAddressToPosition(address: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoConvertPositionData>>
+    func convertAddressToPosition(marketName: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoConvertPositionData>>
 }
 
 
@@ -107,12 +107,12 @@ final class MarketService: MarketServiceProtocol {
     }
     
     // MARK: - 카카오 API를 통해 키워드로 매장 정보 받아오기 API
-    func searchKakaoMarketKeyword(keyword: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoMarketData>> {
-        return await networkService.requestKakaoAPI(KakaoAPIEndpoint.searchKakaoMarketKeyword(keyword: keyword))
+    func searchKakaoMarketKeyword(keyword: String, x: String, y: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoMarketData>> {
+        return await networkService.requestKakaoAPI(KakaoAPIEndpoint.searchKakaoMarketKeyword(keyword: keyword, x: x, y: y))
     }
     
     // MARK: - 매장 주소를 위도, 경도로 변환하기 API (KAKAO API)
-    func convertAddressToPosition(address: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoConvertPositionData>> {
-        return await networkService.requestKakaoAPI(KakaoAPIEndpoint.convertAddressToPositionWithKakaoAPI(address: address))
+    func convertAddressToPosition(marketName: String) async -> NetworkResult<KakaoMarketsDataResDto<KakaoConvertPositionData>> {
+        return await networkService.requestKakaoAPI(KakaoAPIEndpoint.convertAddressToPositionWithKakaoAPI(marketName: marketName))
     }
 }

--- a/MarketPlace/View/Main/View/MarketDetailView.swift
+++ b/MarketPlace/View/Main/View/MarketDetailView.swift
@@ -127,7 +127,7 @@ struct MarketDetailView: View {
                         StoreSearchButton(shopName: shop.name, onTap: {
                             Task {
                                 let (latitude, longitude) = try await ConvertAddress().getPositionFromRoadAddress(from: viewModel.marketDetail?.address ?? "")
-                                openKakaoMap(latitude: latitude, longitude: longitude)
+                                openKakaoMap(latitude: latitude, longitude: longitude, name: shop.name)
                             }
                         })
                         .padding(.horizontal, 24)
@@ -177,8 +177,9 @@ struct MarketDetailView: View {
         }
     }
     
-    func openKakaoMap(latitude: Double, longitude: Double) {
+    func openKakaoMap(latitude: Double, longitude: Double, name: String) {
         let urlString = "kakaomap://look?p=\(latitude),\(longitude)"
+//        let urlString = " kakaomap://search?q=\(name)&p=\(latitude),\(longitude)"
         guard let encodedStr = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
               let url = URL(string: encodedStr),
               let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id304608425")

--- a/MarketPlace/View/Main/View/MarketDetailView.swift
+++ b/MarketPlace/View/Main/View/MarketDetailView.swift
@@ -177,16 +177,24 @@ struct MarketDetailView: View {
         }
     }
     
-    func openKakaoMap(latitude: Double, longitude: Double, name: String) {
-        let urlString = "kakaomap://look?p=\(latitude),\(longitude)"
-//        let urlString = " kakaomap://search?q=\(name)&p=\(latitude),\(longitude)"
-        guard let encodedStr = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let url = URL(string: encodedStr),
+    func openKakaoMap(latitude: Double?, longitude: Double?, name: String) {
+        let encodedName = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        
+        var urlString: String
+        if let longitude = longitude, let latitude = latitude {
+            urlString = "kakaomap://search?q=\(encodedName)&p=\(latitude),\(longitude)"
+        } else {
+            urlString = "kakaomap://search?q=\(encodedName)"
+        }
+        
+        guard let url = URL(string: urlString),
               let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id304608425")
         else { return }
         
         UIApplication.shared.open(url, options: [:]) { success in
-            if !success { UIApplication.shared.open(appStoreURL) }
+            if !success {
+                UIApplication.shared.open(appStoreURL)
+            }
         }
     }
 }

--- a/MarketPlace/View/Map/KakaoMapView.swift
+++ b/MarketPlace/View/Map/KakaoMapView.swift
@@ -198,23 +198,18 @@ struct KakaoMapView: UIViewRepresentable {
             guard let view = controller?.getView("mapview") as? KakaoMap else { return }
             guard let layer = view.getLabelManager().getLabelLayer(layerID: _layerName) else { return }
             
-            /// - NOTE: 이전에 선택된 poi style 초기화
-            if let previousSelected = selectedPoiID {
-                layer.getPoi(poiID: previousSelected)?.changeStyle(styleID: "defaultStyle")
-            }
-            
             /// - NOTE: 선택된 poi 정보
             guard let poi = layer.getPoi(poiID: param.poiItem.itemID) else {
                 print("선택된 poi를 찾을 수 없습니다.")
                 return
             }
-                        
-            /// - NOTE: 선택된 poi를 기준으로 Map 이동 & style 변경
-            let cameraUpdate = CameraUpdate.make(target: poi.position, zoomLevel: 16, mapView: view)
-            let cameraAnimation = CameraAnimationOptions(autoElevation: true, consecutive: true, durationInMillis: 4)
-            view.animateCamera(cameraUpdate: cameraUpdate, options: cameraAnimation)
             
             poi.changeStyle(styleID: "selectedStyle", enableTransition: true)
+
+            /// - NOTE: 선택된 poi를 기준으로 Map 이동 & style 변경
+            let cameraUpdate = CameraUpdate.make(target: poi.position, zoomLevel: 20, mapView: view)
+            let cameraAnimation = CameraAnimationOptions(autoElevation: true, consecutive: true, durationInMillis: 200)
+            view.animateCamera(cameraUpdate: cameraUpdate, options: cameraAnimation)
             
             selectedPoiID = poi.itemID
             

--- a/MarketPlace/View/Map/KakaoMapView.swift
+++ b/MarketPlace/View/Map/KakaoMapView.swift
@@ -14,6 +14,15 @@ struct KakaoMapView: UIViewRepresentable {
     @Binding var pois: [KakaoMapPoi]
     @Binding var location: CLLocation
     
+    @Binding var selectedPoi: KakaoMapPoi?
+    
+    init(draw: Binding<Bool>, pois: Binding<[KakaoMapPoi]>, location: Binding<CLLocation>, selectedPoi: Binding<KakaoMapPoi?>) {
+        self._draw = draw
+        self._pois = pois
+        self._location = location
+        self._selectedPoi = selectedPoi
+    }
+    
     func makeUIView(context: Self.Context) -> KMViewContainer {
         let view: KMViewContainer = KMViewContainer(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height))
         context.coordinator.createController(view)
@@ -32,29 +41,32 @@ struct KakaoMapView: UIViewRepresentable {
                     context.coordinator.controller?.activateEngine()
                 }
                 
-                context.coordinator.createPois(pois: pois)
+                context.coordinator.createPois(kakaoMapPois: pois)
             }
         }
+
         else {
             context.coordinator.controller?.pauseEngine()
         }
     }
     
     func makeCoordinator() -> KakaoMapCoordinator {
-        return KakaoMapCoordinator(location: location, pois: pois)
+        return KakaoMapCoordinator(location: location, pois: pois, selectedPoi: $selectedPoi)
     }
 
     static func dismantleUIView(_ uiView: KMViewContainer, coordinator: KakaoMapCoordinator) {
 
     }
     
-    
     class KakaoMapCoordinator: NSObject, MapControllerDelegate {
         var location: CLLocation
         var pois: [KakaoMapPoi]
         var selectedPoiID: String?
+        
+        @Binding var selectedPoi: KakaoMapPoi?
 
-        init(location: CLLocation, pois: [KakaoMapPoi]) {
+        init(location: CLLocation, pois: [KakaoMapPoi], selectedPoi: Binding<KakaoMapPoi?>) {
+            self._selectedPoi = selectedPoi
             self.pois = pois
             self.location = location
             self.first = true
@@ -63,12 +75,12 @@ struct KakaoMapView: UIViewRepresentable {
         }
         
         func createController(_ view: KMViewContainer) {
-
             container = view
             controller = KMController(viewContainer: view)
             controller?.delegate = self
         }
         
+        // MARK: - SubView를 추가합니다.
         func addViews() {
             let defaultPosition: MapPoint = MapPoint(longitude: location.coordinate.longitude, latitude: location.coordinate.latitude)
             let mapviewInfo: MapviewInfo = MapviewInfo(viewName: "mapview", viewInfoName: "map", defaultPosition: defaultPosition, defaultLevel: 15)
@@ -78,7 +90,7 @@ struct KakaoMapView: UIViewRepresentable {
         
         func addViewSucceeded(_ viewName: String, viewInfoName: String) {
             guard let view = controller?.getView("mapview") else {
-                print("mapview가 없습니다.")
+                print("addViewSucceeded: mapview가 없습니다.")
                 return
             }
             
@@ -87,7 +99,7 @@ struct KakaoMapView: UIViewRepresentable {
             if first {
                 createLabelLayer()
                 createPoiStyle()
-                createPois(pois: pois)
+                createPois(kakaoMapPois: pois)
                 first = false
             }
         }
@@ -102,7 +114,7 @@ struct KakaoMapView: UIViewRepresentable {
         // MARK: - poi style을 지정합니다.
         func createPoiStyle() {
             guard let view = controller?.getView("mapview") as? KakaoMap else {
-                print("mapview를 찾을 수 없습니다.")
+                print("createPoiStyle: mapview를 찾을 수 없습니다.")
                 return
             }
             
@@ -137,14 +149,17 @@ struct KakaoMapView: UIViewRepresentable {
             manager.addPoiStyle(selectedPoiStyle)
         }
             
-        func createPois(pois: [KakaoMapPoi]) {
+        // MARK: - 받아온 kakaoMapPois를 통해 실제 UI로 보여줄 수 있는 poi를 생성
+        func createPois(kakaoMapPois: [KakaoMapPoi]) {
             guard let view = controller?.getView("mapview") as? KakaoMap else {
-                print("mapview를 찾을 수 없습니다")
+                print("createPois: mapview를 찾을 수 없습니다")
                 return
             }
+            
             let manager = view.getLabelManager()
+            
             guard let layer = manager.getLabelLayer(layerID: _layerName) else {
-                print("layer를 찾을 수 없습니다")
+                print("createPois: layer를 찾을 수 없습니다")
                 return
             }
             
@@ -153,48 +168,62 @@ struct KakaoMapView: UIViewRepresentable {
             var poiOptions = [PoiOptions]()
             var positions = [MapPoint]()
 
-            for poi in pois {
+            for data in kakaoMapPois {
                 let option = PoiOptions(styleID: "defaultStyle")
-                option.addText(PoiText(text: poi.title, styleIndex: 0))
+                option.addText(PoiText(text: data.title, styleIndex: 0))
                 option.clickable = true
 
                 poiOptions.append(option)
-                positions.append(MapPoint(longitude: poi.longitude, latitude: poi.latitude))
+                positions.append(MapPoint(longitude: data.longitude, latitude: data.latitude))
             }
             
             guard let pois = layer.addPois(options: poiOptions, at: positions) else {
-                print("pois를 찾을 수 없습니다.")
+                print("createPois: pois를 찾을 수 없습니다.")
                 return
             }
             
-            for poi in pois {
+            /// poi의 userObject에 KakaoMapPoi(사용자 데이터 ex. id, title 등)을 넣어두기 위한 코드
+            /// + poi 클릭 이벤트 설정
+            for (poi, data) in zip(pois, kakaoMapPois) {
+                poi.userObject = KakaoMapPoiWrapper(data)
                 let _ = poi.addPoiTappedEventHandler(target: self, handler: KakaoMapCoordinator.poiTappedHandler)
             }
             
+            self.pois = kakaoMapPois
             layer.showAllPois()
         }
         
+        // MARK: - poi 클릭 이벤트 핸들러
         func poiTappedHandler(_ param: PoiInteractionEventParam) {
             guard let view = controller?.getView("mapview") as? KakaoMap else { return }
             guard let layer = view.getLabelManager().getLabelLayer(layerID: _layerName) else { return }
             
+            /// - NOTE: 이전에 선택된 poi style 초기화
             if let previousSelected = selectedPoiID {
                 layer.getPoi(poiID: previousSelected)?.changeStyle(styleID: "defaultStyle")
             }
             
+            /// - NOTE: 선택된 poi 정보
             guard let poi = layer.getPoi(poiID: param.poiItem.itemID) else {
-                print("pois를 찾을 수 없습니다")
+                print("선택된 poi를 찾을 수 없습니다.")
                 return
             }
-            
+                        
+            /// - NOTE: 선택된 poi를 기준으로 Map 이동 & style 변경
             let cameraUpdate = CameraUpdate.make(target: poi.position, zoomLevel: 16, mapView: view)
             let cameraAnimation = CameraAnimationOptions(autoElevation: true, consecutive: true, durationInMillis: 4)
             view.animateCamera(cameraUpdate: cameraUpdate, options: cameraAnimation)
+            
             poi.changeStyle(styleID: "selectedStyle", enableTransition: true)
             
             selectedPoiID = poi.itemID
-        }
             
+            if let wrapper = poi.userObject as? KakaoMapPoiWrapper,
+               let match = pois.first(where: { $0.id == wrapper.poi.id }) {
+                selectedPoi = match
+            }
+        }
+        
         func containerDidResized(_ size: CGSize) {
             let mapView: KakaoMap? = controller?.getView("mapview") as? KakaoMap
             mapView?.viewRect = CGRect(origin: CGPoint(x: 0.0, y: 0.0), size: size)
@@ -208,6 +237,10 @@ struct KakaoMapView: UIViewRepresentable {
                     mapView: mapView!
                 )
                 mapView?.moveCamera(cameraUpdate)
+                
+                createLabelLayer()
+                createPoiStyle()
+                createPois(kakaoMapPois: pois)
                 first = false
             }
         }

--- a/MarketPlace/View/Map/View/MapView.swift
+++ b/MarketPlace/View/Map/View/MapView.swift
@@ -21,12 +21,17 @@ struct MapView: View {
     var body: some View {
         NavigationView {
             ZStack(alignment: .bottom) {
+                // MARK: - 지도탭 ZStack 가장 하단 (KakaoMapView)
                 KakaoMapView(draw: $draw, pois: $viewModel.marketsForMap, location: $location)
                     .onAppear(perform: {
                         self.draw = true
                         self.location = locationManager.region
                         Task {
-                            await viewModel.fetchMarketsWithAddress(lastPageIndex: nil, category: Category(index: selectedCategory)?.toString() ?? nil, pageSize: nil)
+                            await viewModel.fetchMarketsWithAddress(
+                                lastPageIndex: nil,
+                                category: Category(index: selectedCategory)?.toString() ?? nil,
+                                pageSize: nil
+                            )
                         }
                     })
                     .onDisappear(perform: {
@@ -36,6 +41,7 @@ struct MapView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .ignoresSafeArea()
                     
+                // MARK: - 지도탭 VStack 기준 상단 카테고리 탭뷰
                 VStack {
                     CategoryTabView(selectedTab: $selectedCategory)
                         .background(Color.white)
@@ -43,6 +49,7 @@ struct MapView: View {
                     Spacer()
                 }
                 
+                // MARK: - 지도뷰의 우상단 현재 위치로 이동하는 버튼 뷰
                 VStack {
                     HStack {
                         Spacer()
@@ -193,21 +200,5 @@ struct MapView: View {
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
-    }
-}
-
-extension View {
-    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
-        clipShape(RoundedCorner(radius: radius, corners: corners))
-    }
-}
-
-struct RoundedCorner: Shape {
-    var radius: CGFloat = .infinity
-    var corners: UIRectCorner = .allCorners
-
-    func path(in rect: CGRect) -> Path {
-        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
-        return Path(path.cgPath)
     }
 }

--- a/MarketPlace/View/Map/View/MapView.swift
+++ b/MarketPlace/View/Map/View/MapView.swift
@@ -28,17 +28,13 @@ struct MapView: View {
                     .onAppear(perform: {
                         Task {
                             self.location = locationManager.region
-                            self.draw = false
+                            self.draw = true
                             
                             await viewModel.fetchMarketsWithAddress(
                                 lastPageIndex: nil,
                                 category: Category(index: selectedCategory)?.toString() ?? nil,
-                                pageSize: nil
+                                pageSize: 20
                             )
-                            
-                            DispatchQueue.main.async {
-                                self.draw = true
-                            }
                         }
                     })
                     .onDisappear(perform: {

--- a/MarketPlace/View/Map/View/MapView.swift
+++ b/MarketPlace/View/Map/View/MapView.swift
@@ -18,20 +18,27 @@ struct MapView: View {
     @State private var selectedCategory = 0
     @State private var isSelectedPin: Int = -1
     
+    @State private var selectedPoi: KakaoMapPoi?
+    
     var body: some View {
         NavigationView {
             ZStack(alignment: .bottom) {
                 // MARK: - 지도탭 ZStack 가장 하단 (KakaoMapView)
-                KakaoMapView(draw: $draw, pois: $viewModel.marketsForMap, location: $location)
+                KakaoMapView(draw: $draw, pois: $viewModel.marketsForMap, location: $location, selectedPoi: $selectedPoi)
                     .onAppear(perform: {
-                        self.draw = true
-                        self.location = locationManager.region
                         Task {
+                            self.location = locationManager.region
+                            self.draw = false
+                            
                             await viewModel.fetchMarketsWithAddress(
                                 lastPageIndex: nil,
                                 category: Category(index: selectedCategory)?.toString() ?? nil,
                                 pageSize: nil
                             )
+                            
+                            DispatchQueue.main.async {
+                                self.draw = true
+                            }
                         }
                     })
                     .onDisappear(perform: {
@@ -191,6 +198,10 @@ struct MapView: View {
                     await viewModel.fetchMarkets(category: Category(index: selectedCategory)?.toString() ?? nil)
                     await viewModel.fetchMarketsWithAddress(lastPageIndex: nil, category: Category(index: selectedCategory)?.toString() ?? nil, pageSize: nil)
                 }
+            })
+            .onChange(of: selectedPoi, initial: true, {
+                guard let selectedPoi = selectedPoi else { return }                
+                viewModel.moveMarketToFront(withId: selectedPoi.id)
             })
             .onChange(of: selectedCategory) {
                 Task {

--- a/MarketPlace/View/Request/RequestMarketMapView.swift
+++ b/MarketPlace/View/Request/RequestMarketMapView.swift
@@ -14,6 +14,7 @@ struct RequestMarketMapView: View {
     @StateObject private var viewModel = RequestMarketMapViewModel()
     @State var pois: [KakaoMapPoi]
     @State var location: CLLocation
+    @State var selectedPoi: KakaoMapPoi? /// 역할없음
     
     let market: KakaoMarketData
     
@@ -22,7 +23,7 @@ struct RequestMarketMapView: View {
         let latitude = Double(market.y) ?? 0.0
         let longitude = Double(market.x) ?? 0.0
         
-        _pois = State(initialValue: [KakaoMapPoi(latitude: latitude, longitude: longitude, title: market.place_name)])
+        _pois = State(initialValue: [KakaoMapPoi(latitude: latitude, longitude: longitude, title: market.place_name, id: 0)])
         _location = State(initialValue: CLLocation(latitude: latitude, longitude: longitude))
     }
     
@@ -45,7 +46,7 @@ struct RequestMarketMapView: View {
             HStack {
                 Spacer()
                 
-                KakaoMapView(draw: $draw, pois: $pois, location: $location)
+                KakaoMapView(draw: $draw, pois: $pois, location: $location, selectedPoi: $selectedPoi)
                     .onAppear(perform: {
                         self.draw = true
                     })

--- a/MarketPlace/ViewModel/Map/MapViewModel.swift
+++ b/MarketPlace/ViewModel/Map/MapViewModel.swift
@@ -77,14 +77,10 @@ final class MapViewModel: ObservableObject {
         case .success(let data, _):
             /// - NOTE: 서버에서 받아오는 주소를 위도, 경도 값으로 변경
             self.marketsForMap = await data.response.marketResDtos.asyncMap { market in
-//                var poi = KakaoMapPoi(latitude: 0.0, longitude: 0.0, title: market.marketName, id: market.id)
-//                let position = try? await convertAddressToPosition(address: market.address)
-//                poi.latitude = Double(position?.x ?? "0") ?? 0.0
-//                poi.longitude = Double(position?.y ?? "0") ?? 0.0
                 var poi = KakaoMapPoi(latitude: 0.0, longitude: 0.0, title: market.marketName, id: market.id)
-                let position = try? await ConvertAddress().getCoordinateFromRoadAddress(from: market.address)
-                poi.latitude = position?.latitude ?? 0.0
-                poi.longitude = position?.longitude ?? 0.0
+                let position = try? await convertAddressToPosition(marketName: market.marketName)
+                poi.longitude = Double(position?.x ?? "0") ?? 0.0
+                poi.latitude = Double(position?.y ?? "0") ?? 0.0
                 return poi
             }
             
@@ -104,8 +100,8 @@ final class MapViewModel: ObservableObject {
     }
     
     // MARK: - 매장 주소를 위도, 경도로 변환하기 API (KAKAO API)
-    private func convertAddressToPosition(address: String) async throws -> KakaoConvertPositionData {
-        let result = await marketService.convertAddressToPosition(address: address)
+    private func convertAddressToPosition(marketName: String) async throws -> KakaoConvertPositionData {
+        let result = await marketService.convertAddressToPosition(marketName: marketName)
         
         switch result {
         case .success(let data, let statusCode):
@@ -113,7 +109,7 @@ final class MapViewModel: ObservableObject {
                 print("[convertAddressToPosition] - [\(statusCode)]: 결과 없음")
                 return KakaoConvertPositionData(x: "0", y: "0")
             }
-             
+                        
             return first
         case .failure(let statusCode, let message):
             print("[convertAddressToPosition] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")

--- a/MarketPlace/ViewModel/Map/MapViewModel.swift
+++ b/MarketPlace/ViewModel/Map/MapViewModel.swift
@@ -77,12 +77,17 @@ final class MapViewModel: ObservableObject {
         case .success(let data, _):
             /// - NOTE: 서버에서 받아오는 주소를 위도, 경도 값으로 변경
             self.marketsForMap = await data.response.marketResDtos.asyncMap { market in
-                var poi = KakaoMapPoi(latitude: 0.0, longitude: 0.0, title: market.marketName)
+//                var poi = KakaoMapPoi(latitude: 0.0, longitude: 0.0, title: market.marketName, id: market.id)
+//                let position = try? await convertAddressToPosition(address: market.address)
+//                poi.latitude = Double(position?.x ?? "0") ?? 0.0
+//                poi.longitude = Double(position?.y ?? "0") ?? 0.0
+                var poi = KakaoMapPoi(latitude: 0.0, longitude: 0.0, title: market.marketName, id: market.id)
                 let position = try? await ConvertAddress().getCoordinateFromRoadAddress(from: market.address)
                 poi.latitude = position?.latitude ?? 0.0
                 poi.longitude = position?.longitude ?? 0.0
                 return poi
             }
+            
         case .failure(let statusCode, let message):
             print("[fetchMarketsWithAddress] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
         }
@@ -96,5 +101,23 @@ final class MapViewModel: ObservableObject {
 
         let market = markets.remove(at: index)
         markets.insert(market, at: 0)
+    }
+    
+    // MARK: - 매장 주소를 위도, 경도로 변환하기 API (KAKAO API)
+    private func convertAddressToPosition(address: String) async throws -> KakaoConvertPositionData {
+        let result = await marketService.convertAddressToPosition(address: address)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            guard let first = data.documents.first else {
+                print("[convertAddressToPosition] - [\(statusCode)]: 결과 없음")
+                return KakaoConvertPositionData(x: "0", y: "0")
+            }
+             
+            return first
+        case .failure(let statusCode, let message):
+            print("[convertAddressToPosition] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
+            return KakaoConvertPositionData(x: "0", y: "0")
+        }
     }
 }

--- a/MarketPlace/ViewModel/Request/RequestMarketViewModel.swift
+++ b/MarketPlace/ViewModel/Request/RequestMarketViewModel.swift
@@ -1,6 +1,6 @@
 //
 //  MarketRequestViewModel.swift
-//  MarketPlaceㅌ
+//  MarketPlace
 //
 //  Created by 이예나 on 6/19/25.
 //
@@ -17,7 +17,9 @@ final class RequestMarketViewModel: ObservableObject {
     }
        
     func searchKakaoMarketKeyword(keyword: String) async {
-        let result = await marketService.searchKakaoMarketKeyword(keyword: keyword)
+        /// 현재 자신의 위치 넣기
+        /// 없으면 그냥 정확도로..?
+        let result = await marketService.searchKakaoMarketKeyword(keyword: keyword, x: "", y: "")
         
         switch result {
         case .success(let data, _):


### PR DESCRIPTION
## ⭐️ Related Issue
 - #90 

## 📝 Description
- KakaoMapView의 클릭한 Pin이 매장 리스트의 가장 상단으로 올 수 있도록 수정하였습니다.


- Pin이 정확한 위치에 찍히지않고, 아예 나타나지 않는 문제를 해결하였습니다.
   - 매장의 주소를 위도, 경도로 변환하는 과정에서 기존에 사용하던 CoreLocation의 CLGeocoder는 상세주소(A동, 1층 등)를 포함하면 제대로 위치가 변환되지않는 문제가 있었음.
   - 따라서 카카오맵 주소-> 위도, 경도 변환하는 메서드로 진행했고 상세주소는 잘 포함되어 나타났으나, "타임스페이스 A동"과 같은 정확한 건물의 위도,경도가 아니어서 정확성이 떨어졌음.
   - 찾아본 결과 기존에 다른 화면에서 사용하던 키워드 검색 API는 건물의 정확한 위치까지 반환하는 것을 확인하고 해당 API를 사용하여 Pin의 위치를 나타낼 수 있도록 수정함.


- 카카오맵 URL Scheme 넘어가지 않는 문제를 해결하였습니다.
   - 위의 위도경도 변환과 마찬가지로 CLGeocoder가 주소를 위도,경도로 변환하지 못하면 url 생성 과정에서 문제가 생겨 이를 위도,경도가 없을 시에도 처리할 수 있도록 수정함.
<br>


## 📢 Notes