### PR TITLE
[Fix] 카카오맵 뷰 문제 해결

### DIFF
--- a/MarketPlace/View/Cheer/View/CheerView.swift
+++ b/MarketPlace/View/Cheer/View/CheerView.swift
@@ -3,9 +3,10 @@ import SwiftUI
 
 struct CheerView: View {
     @Environment(\.presentationMode) var presentationMode
-    @StateObject private var viewModel = CheerViewModel()
-    @State var upcomingLastIndex: Int = 0
     @EnvironmentObject var loginVM: LoginViewModel
+    @EnvironmentObject var viewModel: CheerViewModel
+    
+    @State var upcomingLastIndex: Int = 0
     
     @State private var hasData: Bool = true
     

--- a/MarketPlace/View/Map/View/MapView.swift
+++ b/MarketPlace/View/Map/View/MapView.swift
@@ -102,7 +102,7 @@ struct MapView: View {
                                 .padding(.vertical, 12)
                             
                             MapMarketListView(viewModel: viewModel, selectedIndex: $selectedCategory)
-                                .frame(height: UIScreen.main.bounds.height / 6)
+                                .frame(height: UIScreen.main.bounds.height / 4)
                         }
                         .frame(maxWidth: .infinity)
                         .background(Color.white)
@@ -139,7 +139,7 @@ struct MapView: View {
                             .padding(.vertical, 12)
                         
                         MapMarketListView(viewModel: viewModel, selectedIndex: $selectedCategory)
-                            .frame(height: UIScreen.main.bounds.height / 2)
+                            .frame(height: UIScreen.main.bounds.height / 1.8)
                     }
                     .frame(maxWidth: .infinity)
                     .background(Color.white.opacity(1))
@@ -185,9 +185,10 @@ struct MapView: View {
                     .background(Color(hex: "#121212"))
                     .cornerRadius(20)
                     .shadow(radius: 2)
-                    .padding(.bottom, 20)
+                    .padding(.bottom, 100)
                 }
             }
+            .ignoresSafeArea(.container, edges: [.bottom])
             .navigationBarHidden(true)
             .onAppear(perform: {
                 Task {

--- a/MarketPlace/ViewModel/Map/MapViewModel.swift
+++ b/MarketPlace/ViewModel/Map/MapViewModel.swift
@@ -29,7 +29,7 @@ final class MapViewModel: ObservableObject {
     func fetchMarkets(
         lastPageIndex: Int? = nil,
         category: String? = nil,
-        pageSize: Int? = nil
+        pageSize: Int? = 40
     ) async {
         if currentCategory != category {
             currentPage = 1


### PR DESCRIPTION
## ⭐️ Related Issue
 - #104 

## 📝 Description
- 맵뷰 핀 클릭 시 매장 리스트의 첫번쨰로 데이터가 변경되지 않는 문제해결
- iOS 26 탭 뷰 아래부분 SafeArea까지 뷰 적용되도록 수정
<br>