### PR TITLE
[Fix] 공감탭 뷰 매장 공감 API DTO 수정 및 데이터 없을 경우 화면 추가

### DIFF
--- a/MarketPlace.xcodeproj/project.pbxproj
+++ b/MarketPlace.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		295DCBB02DED6DC0009B5D82 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295DCBAF2DED6DC0009B5D82 /* MyPageViewModel.swift */; };
 		295DCBB62DED78C0009B5D82 /* MyCouponViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295DCBB52DED78C0009B5D82 /* MyCouponViewModel.swift */; };
 		295DCBB82DED7C92009B5D82 /* CouponStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295DCBB72DED7C92009B5D82 /* CouponStatus.swift */; };
+		295DE7842ED4236400DB16E7 /* CheerMarketResDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295DE7832ED4236400DB16E7 /* CheerMarketResDto.swift */; };
 		296085B72E1B88CD009CE38B /* ConvertAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296085B62E1B88C9009CE38B /* ConvertAddress.swift */; };
 		296085B92E1B8EE5009CE38B /* DropdownMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296085B82E1B8EE5009CE38B /* DropdownMenuView.swift */; };
 		296CF4162DE805EB0000F200 /* KakaoMapsSDK-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 296CF4152DE805EB0000F200 /* KakaoMapsSDK-SPM */; };
@@ -222,6 +223,7 @@
 		295DCBAF2DED6DC0009B5D82 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		295DCBB52DED78C0009B5D82 /* MyCouponViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCouponViewModel.swift; sourceTree = "<group>"; };
 		295DCBB72DED7C92009B5D82 /* CouponStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponStatus.swift; sourceTree = "<group>"; };
+		295DE7832ED4236400DB16E7 /* CheerMarketResDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerMarketResDto.swift; sourceTree = "<group>"; };
 		296085B62E1B88C9009CE38B /* ConvertAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvertAddress.swift; sourceTree = "<group>"; };
 		296085B82E1B8EE5009CE38B /* DropdownMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownMenuView.swift; sourceTree = "<group>"; };
 		2976FA282DFC4B56009782D1 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
@@ -764,6 +766,7 @@
 				290D92D22DE55AD5008AC190 /* CommonMsgResDTO.swift */,
 				290A71AC2E026969009AEAF8 /* TopClosingCouponResDto.swift */,
 				29D19D1B2E13CC2000DEEADD /* KakaoMarketDataResDto.swift */,
+				295DE7832ED4236400DB16E7 /* CheerMarketResDto.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1097,6 +1100,7 @@
 				29BF18C12DE4950700836D7E /* APIResDto.swift in Sources */,
 				B215F2912DE61C8400F53C51 /* AlertView.swift in Sources */,
 				B28A22AF2D64F1ED00E86EF6 /* StoreImageSlider.swift in Sources */,
+				295DE7842ED4236400DB16E7 /* CheerMarketResDto.swift in Sources */,
 				B26F4E8B2E57308F00C39C37 /* NotificationEndpoint.swift in Sources */,
 				B210EC242D3D686500B1551E /* MyHeaderView.swift in Sources */,
 				290A71B12E02792A009AEAF8 /* ShimmerView.swift in Sources */,

--- a/MarketPlace/DTO/CheerMarketResDto.swift
+++ b/MarketPlace/DTO/CheerMarketResDto.swift
@@ -1,0 +1,12 @@
+//
+//  CheerMarketResDto.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 11/24/25.
+//
+
+import Foundation
+
+struct CheerMarketResDto: Decodable {
+    let cheerCount: Int
+}

--- a/MarketPlace/Service/CheerMarketService.swift
+++ b/MarketPlace/Service/CheerMarketService.swift
@@ -18,7 +18,7 @@ protocol CheerMarketServiceProtocol {
     func fetchUpcomingMarket(lastPageIndex: Int?, lastCheerCount: Int?, count: Int?) async -> NetworkResult<APIResDto<MarketResDto<CheerMarketModel>>>
     
     // MARK: - 공감탭 매장 공감하기 API
-    func postCheerMarket(tempMarketId: Int) async -> NetworkResult<CommonMsgResDTO>
+    func postCheerMarket(tempMarketId: Int) async -> NetworkResult<APIResDto<CheerMarketResDto>>
 }
 
 final class CheerMarketService: CheerMarketServiceProtocol {
@@ -74,7 +74,7 @@ final class CheerMarketService: CheerMarketServiceProtocol {
     }
     
     // MARK: - 공감탭 매장 공감하기 API
-    func postCheerMarket(tempMarketId: Int) async -> NetworkResult<CommonMsgResDTO> {
+    func postCheerMarket(tempMarketId: Int) async -> NetworkResult<APIResDto<CheerMarketResDto>> {
         return await networkService.request(
             CheerMarketEndpoint.postCheerMarket(tempMarketId: tempMarketId)
         )

--- a/MarketPlace/View/Cheer/View/CheerListView.swift
+++ b/MarketPlace/View/Cheer/View/CheerListView.swift
@@ -28,7 +28,7 @@ struct CheerListView: View {
             if viewModel.cheerMarkets.isEmpty {
                 VStack(spacing: 10) {
                     Text("이 카테고리에 해당하는 제휴 매장이 존재하지 않습니다.")
-                    Text("원하는 매장을 요청해보세요 !")
+                    Text("원하는 매장을 요청해보세요!")
                 }
                 .pretendardFont(size: 12, weight: .semibold)
                 .foregroundColor(Colors.gray_300)

--- a/MarketPlace/View/Cheer/View/HotCheerView.swift
+++ b/MarketPlace/View/Cheer/View/HotCheerView.swift
@@ -45,18 +45,31 @@ struct HotCheerView: View {
             }
             .padding(.horizontal)
             
-            ScrollView(.horizontal, showsIndicators: false) {
-                LazyHStack(spacing: 12) {
-                    ForEach(Array(hotCheerMarkets.enumerated()), id: \.offset) { index, market in
-                        HotCheerCardCell(viewModel: HotCheerCardCellViewModel(hotCheerMarket: market))
-                            .onAppear {
-                                guard index == hotCheerMarkets.count - 1 else { return }
-                                lastIndex = index
-                            }
-                    }
+            if hotCheerMarkets.isEmpty {
+                VStack(spacing: 10) {
+                    Text("달성 임박한 매장이 없습니다.")
+                    Text("등록된 매장의 공감하기를 통해 새로운 혜택을 받아보세요!")
                 }
-                .padding(.horizontal)
-                .padding(.bottom, 8)
+                .pretendardFont(size: 12, weight: .semibold)
+                .foregroundColor(Colors.gray_300)
+                .padding(.vertical, 60)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+            
+            else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(spacing: 12) {
+                        ForEach(Array(hotCheerMarkets.enumerated()), id: \.offset) { index, market in
+                            HotCheerCardCell(viewModel: HotCheerCardCellViewModel(hotCheerMarket: market))
+                                .onAppear {
+                                    guard index == hotCheerMarkets.count - 1 else { return }
+                                    lastIndex = index
+                                }
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.bottom, 8)
+                }
             }
         }
     }

--- a/MarketPlace/ViewModel/Cheer/CheerCardCellViewModel.swift
+++ b/MarketPlace/ViewModel/Cheer/CheerCardCellViewModel.swift
@@ -30,13 +30,15 @@ final class CheerCardCellViewModel: ObservableObject {
         case .success(let data, let statusCode):
             if case 200..<300 = statusCode {
                 self.isCheer = true
+                self.cheerMarket.cheerCount = data.response.cheerCount
             }
+            
             return true
             
         case .failure(let statusCode, let message):
             print("[postCheerMarket] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
         }
-        return false
         
+        return false
     }
 }


### PR DESCRIPTION
## ⭐️ Related Issue
 - #106 

## 📝 Description
- 매장 공감 시 DTO를 수정하여 공감 직 후 해당 매장의 공감 개수가 반영되도록 수정
- 달성임박 매장 데이터가 없을 시 안내 문구를 띄울 수 있도록 수정
<br>