### PR TITLE
[Fix] 매장 검색 API 페이징 가능하도록 수정

### DIFF
--- a/MarketPlace/Model/Market/MarketSearchModel.swift
+++ b/MarketPlace/Model/Market/MarketSearchModel.swift
@@ -14,6 +14,9 @@ struct MarketSearchModel: Identifiable, Codable {
     var address: String
     var thumbnail: String
     var isNewCoupon: Bool
+    var isClosingCoupon: Bool
+    var major: String
+    var orderNo: Int?
     
     var id: Int { return marketId }
 }

--- a/MarketPlace/View/Search/View/SearchSecondView.swift
+++ b/MarketPlace/View/Search/View/SearchSecondView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SearchSecondView: View {
     @ObservedObject var viewModel: SearchMarketViewModel
     @Binding var lastIndex: Int
+    @Binding var lastPageID: Int
     
     var body: some View {
         ScrollView {
@@ -24,8 +25,12 @@ struct SearchSecondView: View {
                         }
                     }
                     .onAppear {
-                        guard index == viewModel.market.count - 1 else { return }
+                        guard index == viewModel.market.count - 1,
+                              let lastPageIndex = viewModel.lastPageIndex
+                        else { return }
+                        
                         lastIndex = index
+                        lastPageID = lastPageIndex
                     }
                 }
             }.padding()

--- a/MarketPlace/View/Search/View/SearchView.swift
+++ b/MarketPlace/View/Search/View/SearchView.swift
@@ -31,6 +31,7 @@ struct SearchView: View {
     
     @State private var hasData: Bool = true
     @State var lastIndex: Int = 0
+    @State var lastPageID: Int = 0
         
     var body: some View {
         VStack(spacing: 0) {
@@ -64,7 +65,7 @@ struct SearchView: View {
                 
             } else {
                 if hasData {
-                    SearchSecondView(viewModel: viewModel, lastIndex: $lastIndex)
+                    SearchSecondView(viewModel: viewModel, lastIndex: $lastIndex, lastPageID: $lastPageID)
                         .padding(.top, 20)
                         
                 } else{
@@ -87,12 +88,12 @@ struct SearchView: View {
         }
         .onChange(of: lastIndex, { _, newValue in
             Task {
-                hasData = await viewModel.fetchMarkets(lastPageIndex: lastIndex, keyword: viewModel.currentKeyword)
+                hasData = await viewModel.fetchSearchingMarkets(lastPageIndex: lastPageID, keyword: viewModel.currentKeyword)
             }
         })
         .onChange(of: viewModel.searchText) { _, newValue in
             Task {
-                hasData = await viewModel.fetchMarkets(keyword: newValue)
+                hasData = await viewModel.fetchSearchingMarkets(keyword: newValue)
                 viewModel.currentKeyword = newValue
             }
 

--- a/MarketPlace/ViewModel/Search/SearchMarketViewModel.swift
+++ b/MarketPlace/ViewModel/Search/SearchMarketViewModel.swift
@@ -58,7 +58,7 @@ final class SearchMarketViewModel: ObservableObject {
     
     // MARK: - 검색 결과 불러오는 메서드
     @MainActor
-    func fetchMarkets(
+    func fetchSearchingMarkets(
         lastPageIndex: Int? = nil,
         pageSize: Int? = nil,
         keyword: String
@@ -70,7 +70,7 @@ final class SearchMarketViewModel: ObservableObject {
             hasNextPage = true
         }
         
-        guard !isLoading, hasNextPage else { return false }
+        guard !isLoading, hasNextPage else { return hasData }
         
         isLoading = true
         
@@ -95,7 +95,6 @@ final class SearchMarketViewModel: ObservableObject {
             self.hasNextPage = data.response.hasNext
             currentPage += 1
             
-//            self.market = data.response.marketResDtos
             if market.isEmpty {
                 hasData = false
             }


### PR DESCRIPTION
## ⭐️ Related Issue
 - #110 

## 📝 Description
- 매장 검색 API 페이징 가능하도록 수정함
   - 페이징을 위한 재호출 시에 lastPageId를 리스트의 index 번호를 넘기고 있어서 제대로 작동하지 않았음.! 

<br>