### PR TITLE
[Fix] 공감 화면 공감 버튼 상태 문제 해결

### DIFF
--- a/MarketPlace/View/Cheer/View/CheerListView.swift
+++ b/MarketPlace/View/Cheer/View/CheerListView.swift
@@ -23,9 +23,11 @@ struct CheerListView: View {
             // MARK: - 상단 카테고리 탭바
             CircleCategoryTabView(selectedTab: $selectedTab)
                 .padding(.vertical, 10)
-                        
-            // MARK: - 공감 매장이 없을 때 View
-            if viewModel.cheerMarkets.isEmpty {
+            
+            switch viewModel.state {
+                
+            case .idle:
+                
                 VStack(spacing: 10) {
                     Text("이 카테고리에 해당하는 제휴 매장이 존재하지 않습니다.")
                     Text("원하는 매장을 요청해보세요!")
@@ -33,45 +35,56 @@ struct CheerListView: View {
                 .pretendardFont(size: 12, weight: .semibold)
                 .foregroundColor(Colors.gray_300)
                 .padding(.vertical, 50)
-
-            }
-            
-            // MARK: - Event Grid 뷰
-            else {
+                
+            case .empty:
+                
+                VStack(spacing: 10) {
+                    Text("이 카테고리에 해당하는 제휴 매장이 존재하지 않습니다.")
+                    Text("원하는 매장을 요청해보세요!")
+                }
+                .pretendardFont(size: 12, weight: .semibold)
+                .foregroundColor(Colors.gray_300)
+                .padding(.vertical, 50)
+                
+            case .loaded(let markets, let hasNext):
+                
                 LazyVGrid(columns: [
                     GridItem(.flexible(), spacing: 16),
                     GridItem(.flexible(), spacing: 16)
                 ], spacing: 20) {
-                    ForEach(Array(viewModel.cheerMarkets.enumerated()), id: \.offset) { index, market in
+                    ForEach(Array(markets.enumerated()), id: \.offset) { index, market in
                         CheerCardCell(viewModel: CheerCardCellViewModel(cheerMarket: market))
                             .onAppear {
-                                guard index == viewModel.cheerMarkets.count - 1,
-                                      let lastId = viewModel.lastPageIndex
-                                else { return }
-                                
-                                viewModel.currentCategory = Category(index: selectedTab)?.toString()
-                                
-                                Task {
-                                    await viewModel.fetchCheerMarkets(lastPageIndex: lastId, category: Category(index: selectedTab)?.toString() ?? nil)
+                                if index == markets.count-1, hasNext {
+                                    viewModel.action(.loadNextPage)
                                 }
                             }
                     }
                 }
                 .padding()
+                
+            case .error(let message):
+                
+                VStack {
+                    Text("문제가 발생했습니다!")
+                        .foregroundColor(.gray)
+                        .padding(.top, 40)
+                    
+                    Text(message)
+                        .foregroundColor(.gray)
+                    
+                    Spacer()
+                }
+                
             }
         }
-        /// - NOTE: 처음 View가 초기화될 시 해당 탭의 데이터 불러오기
+        /// - NOTE: 이전화면에서 넘어왔을 시 + 초기 화면의 해당 탭의 데이터 불러오기
         .onAppear {
-            Task {
-                await viewModel.fetchCheerMarkets()
-            }
+            viewModel.action(.fetchCheerMarkets(category: Category(index: selectedTab)?.toString()))
         }
         /// - NOTE: 탭 눌렀을 시 해당 탭의 데이터 불러오기
         .onChange(of: selectedTab) {
-            Task {
-                await viewModel.fetchCheerMarkets(category: Category(index: selectedTab)?.toString() ?? nil)
-                viewModel.currentCategory = Category(index: selectedTab)?.toString()
-            }
+            viewModel.action(.fetchCheerMarkets(category: Category(index: selectedTab)?.toString()))
         }
     }
 }

--- a/MarketPlace/ViewModel/Cheer/CheerListViewModel.swift
+++ b/MarketPlace/ViewModel/Cheer/CheerListViewModel.swift
@@ -7,52 +7,90 @@
 
 import Foundation
 
-final class CheerListViewModel: ObservableObject {
-    @Published var cheerMarkets: [CheerMarketModel] = []
-    @Published var lastPageIndex: Int?
-    @Published var currentCategory: String?
-
-    var currentPage: Int = 1
-    var isLoading: Bool = false
-    var hasNextPage: Bool = true
+final class CheerListViewModel: ViewModelable {
+    
+    // MARK: - Types
+    enum Action {
+        case fetchCheerMarkets(pageSize: Int?=10, category: String?)
+        case loadNextPage
+    }
+    
+    enum State {
+        case idle
+        case empty
+        case loaded([CheerMarketModel], hasNext: Bool)
+        case error(String)
+    }
+    
+    
+    // MARK: - Properties
+    @Published private(set) var state: State = .idle
     
     private var cheerMarketService: CheerMarketServiceProtocol
     
+    /// - NOTE: 페이징 구현을 위한 변수
+    private var lastPageIndex: Int?
+    private var currentPage: Int = 1
+    private var hasNextPage: Bool = true
+    private var category: String?
+    private var count: Int?
+    private var currentCategory: String?
+
+
+    // MARK: - Initializer
     init(cheerMarketService: CheerMarketServiceProtocol = CheerMarketService()) {
         self.cheerMarketService = cheerMarketService
     }
 
+    
+    // MARK: - Action
+   func action(_ action: Action) {
+       switch action {
+       case .fetchCheerMarkets(_, let category):
+           Task { await fetchCheerMarketss(category: category, reset: true) }
+       case .loadNextPage:
+           Task { await fetchCheerMarketss(reset: false) }
+       }
+   }
+    
+       
     // MARK: - 공감 매장 기본 조회
-    func fetchCheerMarkets(lastPageIndex: Int? = nil, category: String? = nil , count: Int? = nil) async {
-        if currentCategory != category {
+    private func fetchCheerMarketss(
+        category: String? = nil,
+        reset: Bool
+    ) async {
+        if reset || currentCategory != category {
             currentPage = 1
-            hasNextPage = true
+            lastPageIndex = nil
         }
         
-        guard !isLoading, hasNextPage else { return }
-        
-        isLoading = true
+        currentCategory = category
         
         let result = await cheerMarketService.fetchCheerMarket(lastPageIndex: lastPageIndex, category: category, count: count)
-        
+
         switch result {
         case .success(let data, _):
-            if currentPage == 1 {
-                self.cheerMarkets = data.response.marketResDtos
+            let markets = data.response.marketResDtos
+            
+            if markets.isEmpty && currentPage == 1 {
+                self.state = .empty
+                return
+            }
+            
+            if currentPage > 1  {
+                if case .loaded(let existing, _) = state {
+                    let combined = existing + markets
+                    self.state = .loaded(combined, hasNext: data.response.hasNext)
+                }
             } else {
-                self.cheerMarkets.append(contentsOf: data.response.marketResDtos)
+                self.state = .loaded(markets, hasNext: data.response.hasNext)
             }
-            
-            if let last = data.response.marketResDtos.last {
-                self.lastPageIndex = last.marketId
-            }
-            
-            self.hasNextPage = data.response.hasNext
+                        
+            lastPageIndex = markets.last?.id
             currentPage += 1
-        case .failure(let statusCode, let message):
-            print("[fetchCheerMarkets] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
+            
+        case .failure(let code, let message):
+            self.state = .error("[\(code)] \(message ?? "알 수 없는 오류")")
         }
-        
-        isLoading = false
     }
 }


### PR DESCRIPTION
## ⭐️ Related Issue
 - #106 

## 📝 Description
- 공감 화면에서 공감버튼을 클릭하여 해당 매장이 공감 상태로 변경되었음에도 다른 뷰 이동 후 돌아오면 공감 해제 되어있는 문제
   - **원인>** 다른 뷰에서 공감 뷰로 돌아왔을때 호출되는 API 메서드내부에서 페이징 변수로 인해 새로운 데이터를 불러오는 API가 호출되는게 아닌 이전 데이터가 덮어씌워져서 상태가 다시 공감 버튼 클릭 전으로 돌아왔음

  - **해결>** 이전에 진행하던 ViewModel이 ViewModelable을 채택하도록 변경하는 작업을 통해 페이징 변수에 영향을 받지 않도록 변경하여 문제를 해결함
<br>