### PR TITLE
[Fix]공감 화면 공감권 개수 오류 해결

### DIFF
--- a/MarketPlace.xcodeproj/project.pbxproj
+++ b/MarketPlace.xcodeproj/project.pbxproj
@@ -1381,7 +1381,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"MarketPlace/Preview Content\"";
-				DEVELOPMENT_TEAM = F7GYZYWC6V;
+				DEVELOPMENT_TEAM = 7RR74CRWQW;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MarketPlace/Info.plist;
@@ -1402,7 +1402,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1421,7 +1421,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MarketPlace/Preview Content\"";
-				DEVELOPMENT_TEAM = F7GYZYWC6V;
+				DEVELOPMENT_TEAM = 7RR74CRWQW;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MarketPlace/Info.plist;
@@ -1442,7 +1442,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/MarketPlace.xcodeproj/project.pbxproj
+++ b/MarketPlace.xcodeproj/project.pbxproj
@@ -1402,7 +1402,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace;
+				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace5;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1442,7 +1442,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace;
+				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace5;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/MarketPlace/Model/CheerMarketModel.swift
+++ b/MarketPlace/Model/CheerMarketModel.swift
@@ -4,15 +4,19 @@ struct CheerMarketModel: Codable, Identifiable {
     let marketId: Int
     let marketName: String
     let marketDescription: String?
-    let thumbnail: String
-    var cheerCount: Int
+    let thumbnail: String?
+    var cheerCount: Int?
     var isCheer: Bool
     var dueDate: Int?
-    
+
     var id: Int { marketId }
-    
+
     var dueDateFormmater: Int {
         guard let dueDate = dueDate else { return 0 }
         return dueDate
+    }
+
+    var thumbnailPath: String {
+        thumbnail ?? ""
     }
 }

--- a/MarketPlace/Model/CheerMarketModel.swift
+++ b/MarketPlace/Model/CheerMarketModel.swift
@@ -4,7 +4,7 @@ struct CheerMarketModel: Codable, Identifiable {
     let marketId: Int
     let marketName: String
     let marketDescription: String?
-    let thumbnail: String?
+    let thumbnail: String
     var cheerCount: Int?
     var isCheer: Bool
     var dueDate: Int?
@@ -14,9 +14,5 @@ struct CheerMarketModel: Codable, Identifiable {
     var dueDateFormmater: Int {
         guard let dueDate = dueDate else { return 0 }
         return dueDate
-    }
-
-    var thumbnailPath: String {
-        thumbnail ?? ""
     }
 }

--- a/MarketPlace/View/Cheer/Components/CheerCardCell.swift
+++ b/MarketPlace/View/Cheer/Components/CheerCardCell.swift
@@ -10,7 +10,7 @@ struct CheerCardCell: View {
         VStack(alignment: .leading, spacing: 8) {
             ShimmeringAsyncImage(
                 url: URL(
-                    string: URLManager.shared.baseStringURL + "image/tempMarket/" + viewModel.cheerMarket.thumbnailPath
+                    string: URLManager.shared.baseStringURL + "image/tempMarket/" + viewModel.cheerMarket.thumbnail
                 ),
                 cornerRadius: 0, width: 162, height: 162)
 

--- a/MarketPlace/View/Cheer/Components/CheerCardCell.swift
+++ b/MarketPlace/View/Cheer/Components/CheerCardCell.swift
@@ -10,7 +10,7 @@ struct CheerCardCell: View {
         VStack(alignment: .leading, spacing: 8) {
             ShimmeringAsyncImage(
                 url: URL(
-                    string: URLManager.shared.baseStringURL + "image/tempMarket/" + viewModel.cheerMarket.thumbnail
+                    string: URLManager.shared.baseStringURL + "image/tempMarket/" + viewModel.cheerMarket.thumbnailPath
                 ),
                 cornerRadius: 0, width: 162, height: 162)
 
@@ -28,10 +28,12 @@ struct CheerCardCell: View {
                 .pretendardFont(size: 12, weight: .medium)
                 
                 Spacer()
-                
-                Text("\(viewModel.cheerMarket.cheerCount)")
-                    .pretendardFont(size: 12, weight: .regular)
-                    .foregroundColor(.gray)
+
+                if let cheerCount = viewModel.cheerMarket.cheerCount {
+                    Text("\(cheerCount)")
+                        .pretendardFont(size: 12, weight: .regular)
+                        .foregroundColor(.gray)
+                }
                 Image(systemName: viewModel.isCheer ? "heart.fill" : "heart")
                     .foregroundColor(.gray)
             }

--- a/MarketPlace/View/Cheer/Components/CheerSearchCardCell.swift
+++ b/MarketPlace/View/Cheer/Components/CheerSearchCardCell.swift
@@ -14,7 +14,7 @@ struct CheerSearchCardCell: View {
         HStack(alignment: .top, spacing: 16) {
             ShimmeringAsyncImage(
                 url: URL(
-                    string: URLManager.shared.baseStringURL + "image/tempMarket/" + market.thumbnail
+                    string: URLManager.shared.baseStringURL + "image/tempMarket/" + market.thumbnailPath
                 ),
                 cornerRadius: 4, width: 110, height: 110)
             

--- a/MarketPlace/View/Cheer/Components/CheerSearchCardCell.swift
+++ b/MarketPlace/View/Cheer/Components/CheerSearchCardCell.swift
@@ -14,7 +14,7 @@ struct CheerSearchCardCell: View {
         HStack(alignment: .top, spacing: 16) {
             ShimmeringAsyncImage(
                 url: URL(
-                    string: URLManager.shared.baseStringURL + "image/tempMarket/" + market.thumbnailPath
+                    string: URLManager.shared.baseStringURL + "image/tempMarket/" + market.thumbnail
                 ),
                 cornerRadius: 4, width: 110, height: 110)
             

--- a/MarketPlace/View/Cheer/Components/HotCheerCardCell.swift
+++ b/MarketPlace/View/Cheer/Components/HotCheerCardCell.swift
@@ -19,13 +19,15 @@ struct HotCheerCardCell: View {
         }
     }
 
-    private var status: CheerStatus { viewModel.hotCheerMarket.cheerCount ?? 0>=14 ? .isFinished : .inProgress }
+    private var status: CheerStatus {
+        (viewModel.hotCheerMarket.cheerCount ?? 0) >= 14 ? .isFinished : .inProgress
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             ShimmeringAsyncImage(
                 url: URL(string:
-                            URLManager.shared.baseStringURL + "image/tempMarket/" + viewModel.hotCheerMarket.thumbnail
+                            URLManager.shared.baseStringURL + "image/tempMarket/" + viewModel.hotCheerMarket.thumbnailPath
                     ),
                 cornerRadius: 0,
                 width: 284,

--- a/MarketPlace/View/Cheer/Components/HotCheerCardCell.swift
+++ b/MarketPlace/View/Cheer/Components/HotCheerCardCell.swift
@@ -27,7 +27,7 @@ struct HotCheerCardCell: View {
         VStack(alignment: .leading, spacing: 8) {
             ShimmeringAsyncImage(
                 url: URL(string:
-                            URLManager.shared.baseStringURL + "image/tempMarket/" + viewModel.hotCheerMarket.thumbnailPath
+                            URLManager.shared.baseStringURL + "image/tempMarket/" + viewModel.hotCheerMarket.thumbnail
                     ),
                 cornerRadius: 0,
                 width: 284,

--- a/MarketPlace/View/Cheer/View/CheerView.swift
+++ b/MarketPlace/View/Cheer/View/CheerView.swift
@@ -59,6 +59,7 @@ struct CheerView: View {
             }
             .onAppear{
                 Task {
+                    await viewModel.fetchMemberInfo()
                     await viewModel.fetchUpcomingMarket()
                 }
             }

--- a/MarketPlace/ViewModel/Cheer/CheerCardCellViewModel.swift
+++ b/MarketPlace/ViewModel/Cheer/CheerCardCellViewModel.swift
@@ -25,20 +25,20 @@ final class CheerCardCellViewModel: ObservableObject {
     // MARK: - 공감탭 매장 공감 API
     func postCheerMarket(tempMarketId: Int) async -> Bool {
         let result = await cheerMarketService.postCheerMarket(tempMarketId: tempMarketId)
-        
+
         switch result {
         case .success(let data, let statusCode):
             if case 200..<300 = statusCode {
                 self.isCheer = true
                 self.cheerMarket.cheerCount = data.response.cheerCount
             }
-            
+
             return true
-            
+
         case .failure(let statusCode, let message):
             print("[postCheerMarket] - [\(statusCode)]: \(message ?? "알 수 없는 오류")")
         }
-        
+
         return false
     }
 }

--- a/MarketPlace/ViewModel/Cheer/CheerViewModel.swift
+++ b/MarketPlace/ViewModel/Cheer/CheerViewModel.swift
@@ -36,10 +36,6 @@ final class CheerViewModel: ObservableObject {
     ) {
         self.cheerMarketService = cheerMarketService
         self.memberService = memberService
-        
-        Task {
-            await fetchMemberInfo()
-        }
     }
         
     // MARK: - 달성임박 조회


### PR DESCRIPTION
1. 공감권 개수 초기 로딩 제거
  CheerViewModel은 ContentView에서 앱 시작 시 생성되므로 로그인 전에 여기서 fetchMemberInfo()를 호출하면 실패함/
  -> 대신 CheerView의 onAppear에서 로그인 후 호출하도록 변경


2. 공감권 개수 갱신
  로그인 후 CheerView로 처음 진입할 때 공감권 개수를 다시 가져옴
  -> ContentView에서 CheerViewModel이 생성되는 시점이 로그인 전이므로 로그인 후 화면 진입 시 명시적으로 공감권 개수를 갱신해야 함

3. 검색 결과 통합 처리를 위한 옵셔널 필드
   검색 결과에서는 cheerCount가 없을 수 있음 (공감 여부만 표시)
    thumbnail이 없을 경우 빈 문자열 반환

4. 공감 개수 옵셔널 처리
   검색 결과에서는 cheerCount가 없을 수 있음

5. 공감 상태 판단 (옵셔널 처리)
   cheerCount가 nil이거나 14 이상이면 마감, 아니면 진행중

6. cheerCount 옵셔널 처리
    API 응답으로 받은 cheerCount 업데이트
