### PR TITLE
[Feat] 매장 요청완료 후 첫 번째 뎁스로 돌아갑니다

### DIFF
--- a/MarketPlace/ContentView.swift
+++ b/MarketPlace/ContentView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject var loginVM: LoginViewModel
     @StateObject var cheerViewModel = CheerViewModel()
-    
+
     init() {
         setupTabBarAppearance()
         setupNavigationBarAppearance()
     }
-    
+
     var body: some View {
         TabView {
             MainView()
@@ -20,7 +20,7 @@ struct ContentView: View {
                             .multilineTextAlignment(.center)
                     }
                 }
-            
+
             MapView()
                 .tabItem {
                     VStack {
@@ -33,7 +33,7 @@ struct ContentView: View {
                             .multilineTextAlignment(.center)
                     }
                 }
-            
+
             Group {
                 if loginVM.isLoggedIn {
                     CheerView()
@@ -41,7 +41,8 @@ struct ContentView: View {
                 } else {
                     LoginRequiredView()
                 }
-            }.tabItem {
+            }
+            .tabItem {
                 VStack {
                     Image(systemName: "heart.fill")
                         .resizable()
@@ -52,14 +53,15 @@ struct ContentView: View {
                         .multilineTextAlignment(.center)
                 }
             }
-            
+
             Group {
                 if loginVM.isLoggedIn {
                     MyPageView()
                 } else {
                     LoginRequiredView()
                 }
-            }.tabItem {
+            }
+            .tabItem {
                 VStack {
                     Image(uiImage: resizeImage(named: "userIcon", width: 24, height: 24))
                     Text("마이페이지")

--- a/MarketPlace/MarketPlaceApp.swift
+++ b/MarketPlace/MarketPlaceApp.swift
@@ -39,7 +39,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         } else {
             fatalError("Kakao App Key is missing ")
         }
-        
+
         return true
     }
 }

--- a/MarketPlace/View/Cheer/View/CheerSearchfailedView.swift
+++ b/MarketPlace/View/Cheer/View/CheerSearchfailedView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct CheerSearchfailedView: View {
+    @EnvironmentObject var cheerViewModel: CheerViewModel
+
     var body: some View {
         VStack{
             VStack(alignment: .center) {

--- a/MarketPlace/View/Cheer/View/CheerView.swift
+++ b/MarketPlace/View/Cheer/View/CheerView.swift
@@ -14,16 +14,16 @@ struct CheerView: View {
         NavigationView {
             ScrollView {
                 CheerSearchView(searchText: $viewModel.searchText)
-                
+
                 VStack(spacing:20) {
                     if viewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         HotCheerView(hotCheerMarkets: $viewModel.cheerMarket, cheerTicket: $viewModel.memberCheerTicket, lastIndex: $upcomingLastIndex)
                             .padding(.top, 10)
-                        
+
                         Rectangle()
                             .foregroundStyle(Color(hex: "#EEEEEE"))
                             .frame(height: 4)
-                        
+
                         CheerListView()
                     } else {
                         if hasData {
@@ -39,7 +39,7 @@ struct CheerView: View {
                                             guard index == viewModel.cheerMarket.count - 1,
                                                   let lastId = viewModel.searchLastMarketId
                                             else { return }
-                                            
+
                                             Task {
                                                 await viewModel.fetchSearchCheerMarket(lastPageIndex: lastId, name: viewModel.currentKeyword)
                                             }
@@ -58,6 +58,40 @@ struct CheerView: View {
                 self.endTextEditing()
             }
             .onAppear{
+                print("🔥 CheerView onAppear 호출됨")
+                print("🔥 현재 searchText: '\(viewModel.searchText)'")
+
+                // searchText 초기화
+                viewModel.searchText = ""
+
+                print("🔥 초기화 후 searchText: '\(viewModel.searchText)'")
+
+                // 네비게이션 스택 리셋
+                DispatchQueue.main.async {
+                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                       let window = windowScene.windows.first {
+
+                        func findNavigationController(in viewController: UIViewController?) -> UINavigationController? {
+                            if let navController = viewController as? UINavigationController {
+                                return navController
+                            }
+                            for child in viewController?.children ?? [] {
+                                if let navController = findNavigationController(in: child) {
+                                    return navController
+                                }
+                            }
+                            return nil
+                        }
+
+                        if let tabBarController = window.rootViewController as? UITabBarController,
+                           let selectedVC = tabBarController.selectedViewController,
+                           let navController = findNavigationController(in: selectedVC) {
+                            navController.popToRootViewController(animated: false)
+                            print("✅ 네비게이션 스택 리셋 완료")
+                        }
+                    }
+                }
+
                 Task {
                     await viewModel.fetchMemberInfo()
                     await viewModel.fetchUpcomingMarket()

--- a/MarketPlace/View/Cheer/View/CheerView.swift
+++ b/MarketPlace/View/Cheer/View/CheerView.swift
@@ -58,13 +58,7 @@ struct CheerView: View {
                 self.endTextEditing()
             }
             .onAppear{
-                print("🔥 CheerView onAppear 호출됨")
-                print("🔥 현재 searchText: '\(viewModel.searchText)'")
-
-                // searchText 초기화
                 viewModel.searchText = ""
-
-                print("🔥 초기화 후 searchText: '\(viewModel.searchText)'")
 
                 // 네비게이션 스택 리셋
                 DispatchQueue.main.async {
@@ -87,7 +81,6 @@ struct CheerView: View {
                            let selectedVC = tabBarController.selectedViewController,
                            let navController = findNavigationController(in: selectedVC) {
                             navController.popToRootViewController(animated: false)
-                            print("✅ 네비게이션 스택 리셋 완료")
                         }
                     }
                 }

--- a/MarketPlace/View/Request/RequestMainView.swift
+++ b/MarketPlace/View/Request/RequestMainView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct RequestMainView: View {
     @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject var cheerViewModel: CheerViewModel
 
     @State var marketName: String = ""
     @StateObject private var viewModel = RequestMarketViewModel()
@@ -73,16 +74,13 @@ struct RequestMainView: View {
     }
     
     private func setupNavigationBarAppearance() {
-        /// UINavigationBar의 기본 설정을 수정합니다.
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = UIColor.white
         appearance.titleTextAttributes = [.foregroundColor: UIColor.black]
         
-        /// 기본 back indicator를 숨깁니다.
         appearance.setBackIndicatorImage(UIImage(), transitionMaskImage: UIImage())
         
-        /// 설정된 appearance 적용
         UINavigationBar.appearance().standardAppearance = appearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance
     }

--- a/MarketPlace/View/Request/RequestMarketMapView.swift
+++ b/MarketPlace/View/Request/RequestMarketMapView.swift
@@ -10,12 +10,14 @@ import CoreLocation
 
 struct RequestMarketMapView: View {
     @Environment(\.presentationMode) var presentationMode
-    
+    @EnvironmentObject var cheerViewModel: CheerViewModel
+
     @StateObject private var viewModel = RequestMarketMapViewModel()
     @State var pois: [KakaoMapPoi]
     @State var location: CLLocation
     @State var selectedPoi: KakaoMapPoi? /// 역할없음
-    
+    @State private var showCompletionPopup: Bool = false
+
     let market: KakaoMarketData
     
     init(market: KakaoMarketData) {
@@ -62,7 +64,7 @@ struct RequestMarketMapView: View {
             Button(action: {
                 Task {
                     await viewModel.postMarketRequest(name: market.place_name, address: market.road_address_name)
-                    presentationMode.wrappedValue.dismiss()
+                    showCompletionPopup = true
                 }
             }, label: {
                 Text("입점 요청하기")
@@ -86,6 +88,71 @@ struct RequestMarketMapView: View {
                     Image(systemName: "chevron.backward")
                         .foregroundColor(.black)
                 }
+            }
+        }
+        .overlay(
+            ZStack {
+                if showCompletionPopup {
+                    RequestCompletionPopup(
+                        isPresented: $showCompletionPopup,
+                        onConfirm: {
+                            showCompletionPopup = false
+
+                            cheerViewModel.searchText = ""
+
+                            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                               let window = windowScene.windows.first {
+                                var currentVC = window.rootViewController
+
+                                if let tabBarController = currentVC as? UITabBarController {
+                                    currentVC = tabBarController.selectedViewController
+                                }
+
+                                if let navigationController = currentVC as? UINavigationController {
+                                    navigationController.popToRootViewController(animated: true)
+                                } else if let navigationController = currentVC?.children.first as? UINavigationController {
+                                    navigationController.popToRootViewController(animated: true)
+                                }
+                            }
+                        }
+                    )
+                }
+            }
+        )
+    }
+}
+
+struct RequestCompletionPopup: View {
+    @Binding var isPresented: Bool
+    let onConfirm: () -> Void
+
+    var body: some View {
+        if isPresented {
+            ZStack {
+                Color.black.opacity(0.3)
+                    .ignoresSafeArea()
+
+                VStack(spacing: 30) {
+                    Text("입점 요청이 완료되었습니다.")
+                        .pretendardFont(size: 18, weight: .semibold)
+                        .multilineTextAlignment(.center)
+
+                    Button(action: {
+                        onConfirm()
+                    }) {
+                        Text("OK")
+                            .pretendardFont(size: 15, weight: .bold)
+                            .frame(maxWidth: .infinity, minHeight: 48)
+                            .background(Color.black)
+                            .foregroundColor(.white)
+                            .cornerRadius(8)
+                    }
+                    .padding(.horizontal, 20)
+                }
+                .frame(width: 300, height: 180)
+                .background(Color.white)
+                .cornerRadius(12)
+                .shadow(radius: 10)
             }
         }
     }

--- a/MarketPlace/View/Search/View/SearchFailedView.swift
+++ b/MarketPlace/View/Search/View/SearchFailedView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct SearchFailedView: View {
+    @EnvironmentObject var cheerViewModel: CheerViewModel
+
     var body: some View {
         VStack {
             VStack {


### PR DESCRIPTION
### 1. 매장 요청완료 후 첫 번째 뎁스로 돌아갑니다.

이때, 요청이 완료되었다는 것을 사용자에게 알려야한다는 필요성을 느껴 팝업을 추가하였습니다.
ok 버튼을 누르면 searchText를 초기화하고, 첫번째 뎁스로 이동하도록 설계하였습니다.

### 2. 다른 탭에 갔다왔을 경우 공감탭 화면이 초기화되도록 설정하였습니다.
 
해당 이슈 수정 중에 해당 탭(공감 탭)에서 서치/요청 작업을 하다가 다른 탭에 갔다왔을 경우 초기화되지 않는 경우를 발견했습니다. 즉, 공감 탭에서 작업 중에 다른 탭에 갔다와도 공감 탭의 첫 화면이 보이지 않고 작업중이던 화면이 떠있습니다. 

 이 문제를 해결하기 위해 SwiftUI의 onAppear modifier의 뷰 생명주기 특성을 활용하여, 다른 탭에 갔다왔을 경우 공감탭 화면이 초기화되도록 설정하였습니다. 

푸터 탭 선택 시 공감 탭의 상태를 초기화하고 첫 화면을 노출하는 것이 더 자연스러운 UX라고 생각했습니다. 우리의 푸터 탭은 Top-level destination으로, 보통 사용자가 탭을 다시 선택했을 때는 해당 탭의 진입 화면을 기대하는 UX 패턴입니다. 현재 공감 탭은 다른 탭을 다녀온 후에도 이전 작업 상태가 유지되어, 맥락이 끊긴 사용자에게 매끄럽지 못한 UI를 제공한다고 판단하였습니다.