### PR TITLE
[Fix] 각 페이지 별 안내문구를 추가하였습니다

### DIFF
--- a/MarketPlace.xcodeproj/project.pbxproj
+++ b/MarketPlace.xcodeproj/project.pbxproj
@@ -1381,13 +1381,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"MarketPlace/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AANGG4Q668;
+				DEVELOPMENT_TEAM = 7RR74CRWQW;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MarketPlace/Info.plist;
@@ -1408,10 +1406,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace5;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = currumi;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1425,12 +1422,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MarketPlace/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AANGG4Q668;
+				DEVELOPMENT_TEAM = 7RR74CRWQW;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MarketPlace/Info.plist;
@@ -1451,10 +1446,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.appcenter.MarketPlace5;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = currumi;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/MarketPlace/View/Main/View/CategoryDetailView.swift
+++ b/MarketPlace/View/Main/View/CategoryDetailView.swift
@@ -8,31 +8,48 @@ struct CategoryDetailView: View {
         VStack {
             // MARK: - Category 목록 상단 TabView
             CategoryTabView(selectedTab: $selectedTab)
-            
-            ScrollView {
-                LazyVStack(spacing: 16) {
-                    ForEach(Array(viewModel.markets.enumerated()), id: \.offset) { index, shop in
-                        NavigationLink(destination: MarketDetailView(marketId: shop.marketId, isBookmarked: shop.isFavorite)) {
-                            VStack {
-                                MarketInfoCell(
-                                    isBookmarked: shop.isFavorite,
-                                    viewModel: MarketInfoCellViewModel(marketData: shop)
-                                )
-                                
-                                Divider()
-                                    .background(Color.gray.opacity(0.5))
-                                    .padding(.horizontal, -20)
+
+            if viewModel.markets.isEmpty {
+                /// - NOTE: 매장이 없을 때
+                VStack(spacing: 20) {
+                    Spacer()
+
+                    Text("아직 입점된 매장이 없습니다.\n공감화면에서 원하는 매장을 요청해보세요!")
+                        .pretendardFont(size: 16, weight: .regular)
+                        .foregroundColor(Colors.gray_600)
+                        .multilineTextAlignment(.center)
+                        .lineSpacing(8)
+
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                // MARK: - 매장 목록
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        ForEach(Array(viewModel.markets.enumerated()), id: \.offset) { index, shop in
+                            NavigationLink(destination: MarketDetailView(marketId: shop.marketId, isBookmarked: shop.isFavorite)) {
+                                VStack {
+                                    MarketInfoCell(
+                                        isBookmarked: shop.isFavorite,
+                                        viewModel: MarketInfoCellViewModel(marketData: shop)
+                                    )
+
+                                    Divider()
+                                        .background(Color.gray.opacity(0.5))
+                                        .padding(.horizontal, -20)
+                                }
                             }
-                        }
-                        .onAppear {
-                            guard index == viewModel.markets.count - 1,
-                                  let lastId = viewModel.lastMarketId
-                            else { return }
-                                                        
-                            viewModel.currentCategory = Category(index: selectedTab)?.toString()
-                            
-                            Task {
-                                await viewModel.fetchMarkets(lastPageIndex: lastId, category: Category(index: selectedTab)?.toString() ?? nil)
+                            .onAppear {
+                                guard index == viewModel.markets.count - 1,
+                                      let lastId = viewModel.lastMarketId
+                                else { return }
+
+                                viewModel.currentCategory = Category(index: selectedTab)?.toString()
+
+                                Task {
+                                    await viewModel.fetchMarkets(lastPageIndex: lastId, category: Category(index: selectedTab)?.toString() ?? nil)
+                                }
                             }
                         }
                     }

--- a/MarketPlace/View/Map/View/MapMarketListView.swift
+++ b/MarketPlace/View/Map/View/MapMarketListView.swift
@@ -12,6 +12,17 @@ struct MapMarketListView: View {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle())
                         .padding()
+                } else if viewModel.markets.isEmpty {
+                    /// - NOTE: 매장이 없을 때
+                    VStack(spacing: 20) {
+                        Text("아직 입점된 매장이 없습니다.\n공감화면에서 원하는 매장을 요청해보세요!")
+                            .pretendardFont(size: 16, weight: .regular)
+                            .foregroundColor(Colors.gray_600)
+                            .multilineTextAlignment(.center)
+                            .lineSpacing(8)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 40)
                 } else {
                     ForEach(Array(viewModel.markets.enumerated()), id: \.offset) { index, shop in
                         NavigationLink(destination:
@@ -22,7 +33,7 @@ struct MapMarketListView: View {
                                     isBookmarked: shop.isFavorite,
                                     viewModel: MarketInfoCellViewModel(marketData: shop)
                                 ).padding(.bottom, 10)
-                                
+
                                 Divider()
                                     .background(Color.gray.opacity(0.5))
                                     .padding(.horizontal, -20)
@@ -32,9 +43,9 @@ struct MapMarketListView: View {
                             guard index == viewModel.markets.count - 1,
                                   let lastId = viewModel.lastMarketId
                             else { return }
-                                                        
+
                             viewModel.currentCategory = Category(index: selectedIndex)?.toString()
-                            
+
                             Task {
                                 await viewModel.fetchMarkets(lastPageIndex: lastId, category: Category(index: selectedIndex)?.toString() ?? nil)
                             }

--- a/MarketPlace/View/MyPage/View/MyFavoriteShopListView.swift
+++ b/MarketPlace/View/MyPage/View/MyFavoriteShopListView.swift
@@ -5,40 +5,58 @@ struct MyFavoriteShopListView: View {
     @StateObject var viewModel = MyFavoriteMarketListViewModel()
     
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: 16) {
-                ForEach(Array(viewModel.favoriteMarkets.enumerated()),id: \.offset) { index, shop in
-                    NavigationLink(destination:
-                        MarketDetailView(marketId: shop.marketId, isBookmarked: shop.isFavorite)
-                    ) {
-                        let market = MarketModel(
-                            marketId: shop.marketId,
-                            marketName: shop.marketName,
-                            marketDescription: shop.marketDescription,
-                            address: shop.address,
-                            thumbnail: shop.thumbnail,
-                            isFavorite: shop.isFavorite,
-                            isNewCoupon: shop.isNewCoupon
-                        )
-                        
-                        VStack {
-                            MarketInfoCell(
-                                isBookmarked: shop.isFavorite,
-                                viewModel: MarketInfoCellViewModel(marketData: market)
-                            )
-                            
-                            Divider()
-                                .background(Color.gray.opacity(0.5))
-                                .padding(.horizontal, -20)
-                        }
-                    }
-                    .onAppear {
-                        guard index == viewModel.favoriteMarkets.count - 1,
-                              let lastModified = viewModel.lastModified
-                        else { return }
-                        
-                        Task {
-                            await viewModel.fetchFavoriteMarket(lastModifiedAt: lastModified)
+        Group {
+            if viewModel.favoriteMarkets.isEmpty {
+                /// - NOTE: 저장한 매장이 없을 때
+                VStack(spacing: 20) {
+                    Spacer()
+
+                    Text("내가 저장한 매장이 없습니다.\n카테고리 페이지에서 관심있는 매장을 저장해보세요.")
+                        .pretendardFont(size: 16, weight: .regular)
+                        .foregroundColor(Colors.gray_600)
+                        .multilineTextAlignment(.center)
+                        .lineSpacing(8)
+
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        ForEach(Array(viewModel.favoriteMarkets.enumerated()),id: \.offset) { index, shop in
+                            NavigationLink(destination:
+                                MarketDetailView(marketId: shop.marketId, isBookmarked: shop.isFavorite)
+                            ) {
+                                let market = MarketModel(
+                                    marketId: shop.marketId,
+                                    marketName: shop.marketName,
+                                    marketDescription: shop.marketDescription,
+                                    address: shop.address,
+                                    thumbnail: shop.thumbnail,
+                                    isFavorite: shop.isFavorite,
+                                    isNewCoupon: shop.isNewCoupon
+                                )
+
+                                VStack {
+                                    MarketInfoCell(
+                                        isBookmarked: shop.isFavorite,
+                                        viewModel: MarketInfoCellViewModel(marketData: market)
+                                    )
+
+                                    Divider()
+                                        .background(Color.gray.opacity(0.5))
+                                        .padding(.horizontal, -20)
+                                }
+                            }
+                            .onAppear {
+                                guard index == viewModel.favoriteMarkets.count - 1,
+                                      let lastModified = viewModel.lastModified
+                                else { return }
+
+                                Task {
+                                    await viewModel.fetchFavoriteMarket(lastModifiedAt: lastModified)
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
기존에 카테고리, 지도, 나만의 큐레이션 페이지에서 매장 정보를 받아오지 않을 경우 빈화면이 떠있었습니다.
사용자에게 로딩중이라는 혼란을 야기할 수 있기 때문에 아래와 같은 문구를 추가하였습니다. 

<img width="1170" height="2532" alt="IMG_9427" src="https://github.com/user-attachments/assets/d895ebc7-13fd-4b10-bb49-de2f992c35ad" />

<img width="1170" height="2532" alt="IMG_9425" src="https://github.com/user-attachments/assets/d18e9669-72a5-4074-bfb2-21af12767e17" />

<img width="1170" height="2532" alt="IMG_9426" src="https://github.com/user-attachments/assets/80b4b2c9-5bcd-478a-95f8-3f85c75823d4" />
