### PR TITLE
[Fix] login UI 수정

### DIFF
--- a/MarketPlace/View/Login/LoginView.swift
+++ b/MarketPlace/View/Login/LoginView.swift
@@ -87,7 +87,7 @@ struct LoginView: View {
                         .pretendardFont(size: 14, weight: .regular)
                         .foregroundColor(Color(red: 0.2, green: 0.2, blue: 0.2))
                     
-                    TextField("학번을 입력해 주세요.", text: $studentID)
+                    TextField("학교 포털 아이디를 입력해 주세요", text: $studentID)
                         .pretendardFont(size: 13, weight: .regular)
                         .keyboardType(.numberPad)
                         .padding()
@@ -104,7 +104,7 @@ struct LoginView: View {
                         .pretendardFont(size: 14, weight: .regular)
                         .foregroundColor(Color(red: 0.2, green: 0.2, blue: 0.2))
                     
-                    SecureField("비밀번호는 꼭꼭 지켜줄게요", text: $password)
+                    SecureField("학교 포털 비밀번호를 입력해주세요", text: $password)
                         .pretendardFont(size: 13, weight: .regular)
                         .padding()
                         .frame(height: 48)
@@ -114,17 +114,20 @@ struct LoginView: View {
                         .focused($isEditing)
                 }
                 
-                Text("학교 포털 아이디 / 비밀번호를 적어주세요!")
-                    .pretendardFont(size: 12, weight: .medium)
-                    .foregroundColor(Color(red: 0.2, green: 0.2, blue: 0.2))
-                
-                if !isEditing, let errorMessage = viewModel.userErrorMessage {
-                    Text(errorMessage)
-                        .pretendardFont(size: 14, weight: .regular)
-                        .foregroundColor(.red)
-                        .padding(.top, 10)
+                HStack(spacing: 20) {
+                    CheckboxView(title: "계정 정보 저장", isChecked: $saveAccount, action: { _ in })
                 }
-                
+//                Text("학교 포털 아이디 / 비밀번호를 적어주세요!")
+//                    .pretendardFont(size: 12, weight: .medium)
+//                    .foregroundColor(Color(red: 0.2, green: 0.2, blue: 0.2))
+//                
+//                if !isEditing, let errorMessage = viewModel.userErrorMessage {
+//                    Text(errorMessage)
+//                        .pretendardFont(size: 14, weight: .regular)
+//                        .foregroundColor(.red)
+//                        .padding(.top, 10)
+//                }
+//                
                 // MARK: - 로그인 버튼
                 Button(action: {
                     Task {
@@ -142,9 +145,6 @@ struct LoginView: View {
                         .cornerRadius(8)
                 }.disabled(studentID.isEmpty || password.isEmpty)
                 
-                HStack(spacing: 20) {
-                    CheckboxView(title: "계정 정보 저장", isChecked: $saveAccount, action: { _ in })
-                }
             }
             .padding(.horizontal, 20)
             

--- a/MarketPlace/View/Login/LoginView.swift
+++ b/MarketPlace/View/Login/LoginView.swift
@@ -38,12 +38,8 @@ struct LoginView: View {
                 .padding(.leading, 20)
             
             VStack(alignment: .leading, spacing: 10) {
-                Text("매번 마라탕 한 그릇, 이천 원 더 내고 있어요.")
+                Text("이제, 인천대 제휴 할인을 받으러 가볼까요?")
                     .pretendardFont(size: 12, weight: .semibold)
-                    .foregroundColor(Color(red: 0.2, green: 0.2, blue: 0.2))
-                
-                Text("이제, 다니는 대학 제휴 멤버십으로 \n쿠폰 꾸러미 받아볼까요?")
-                    .pretendardFont(size: 16, weight: .medium)
                     .foregroundColor(Color(red: 0.2, green: 0.2, blue: 0.2))
             }
             .padding(.horizontal, 20)


### PR DESCRIPTION
기존 회원가입 화면에서 안내 문구가 입력 필드 외부에 위치하여 다음과 같은 문제가  발생했습니다
  - 정보 계층 구조 불명확: 안내 문구로 인해 계정정보 저장 체크박스가 하단으로 밀려나 시각적 우선순위가 낮아짐
  - 인지 부하 증가: 사용자가 중요한 동의 옵션을 인지하기 어려운 레이아웃 구조

따라서, 안내 문구 위치를 입력 필드 외부 → TextField placeholder로 이동하였고, 체크박스 배치를 사용자 동선상 자연스러운 위치로 재배치하였습니다.
<img width="1170" height="2532" alt="IMG_9429" src="https://github.com/user-attachments/assets/eae83e63-efb0-4cec-ab32-939845428456" />
<img width="1170" height="2532" alt="IMG_9428" src="https://github.com/user-attachments/assets/eb65875e-3758-40ae-87e1-3294c8c53675" />
