### PR TITLE
[Feat] 매장 및 공감매장 도메인 Repository protocol 및 구현체를 추가합니다.

### DIFF
--- a/MarketPlace/Data/Network/DTO/CheerMarket/CheerMarketResDto.swift
+++ b/MarketPlace/Data/Network/DTO/CheerMarket/CheerMarketResDto.swift
@@ -23,3 +23,17 @@ struct CheerMarketResDto: Codable, Identifiable {
         return dueDate
     }
 }
+
+extension CheerMarketResDto {
+    func toEntity() -> CheerMarketModel {
+        return CheerMarketModel(
+            id: marketId,
+            name: marketName,
+            description: marketDescription,
+            thumbnail: thumbnail,
+            cheerCount: cheerCount,
+            isCheer: isCheer,
+            dueDate: dueDateFormmater
+        )
+    }
+}

--- a/MarketPlace/Data/Repositories/DefaultCheerMarketRepository.swift
+++ b/MarketPlace/Data/Repositories/DefaultCheerMarketRepository.swift
@@ -1,0 +1,138 @@
+//
+//  DefaultCheerMarketRepository.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 3/9/26.
+//
+
+import Foundation
+
+final class DefaultCheerMarketRepository {
+    private let cheerMarketNetworkService: CheerMarketServiceProtocol
+    private let memberNetworkService: MemberServiceProtocol
+    private let marketNetworkService: MarketServiceProtocol
+    
+    init(
+        cheerMarketNetworkService: CheerMarketServiceProtocol,
+        memberNetworkService: MemberServiceProtocol,
+        marketNetworkService: MarketServiceProtocol
+    ) {
+        self.cheerMarketNetworkService = cheerMarketNetworkService
+        self.memberNetworkService = memberNetworkService
+        self.marketNetworkService = marketNetworkService
+    }
+}
+
+extension DefaultCheerMarketRepository: CheerMarketRepository {
+    func fetchCheerMarketWithCategory(category: MarketCategory, lastPageIndex: Int?, page: Int?) async -> Result<[CheerMarketModel], MarketRepositoryError> {
+        let result = await cheerMarketNetworkService.fetchCheerMarket(lastPageIndex: lastPageIndex, category: category.toString(), count: page)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let cheerMarkets = data.response.marketResDtos.map {
+                $0.toEntity()
+            }
+            
+            return .success(cheerMarkets)
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+            
+        }
+    }
+    
+    func fetchMarketQueries(keyword: String, lastPageIndex: Int?, pageSize: Int?) async -> Result<[CheerMarketModel], MarketRepositoryError> {
+        let result = await cheerMarketNetworkService.fetchSearchCheerMarket(lastPageIndex: lastPageIndex, pageSize: pageSize, name: keyword)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let cheerMarkets = data.response.marketResDtos.map {
+                $0.toEntity()
+            }
+            
+            return .success(cheerMarkets)
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+            
+        }
+    }
+    
+    func fetchUpcomingCheerMarket(lastPageIndex: Int, lastCheerCount: Int?, page: Int?) async -> Result<[CheerMarketModel], MarketRepositoryError> {
+        let result = await cheerMarketNetworkService.fetchUpcomingMarket(lastPageIndex: lastPageIndex, lastCheerCount: lastCheerCount, count: page)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let cheerMarkets = data.response.marketResDtos.map {
+                $0.toEntity()
+            }
+            
+            return .success(cheerMarkets)
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+            
+        }
+    }
+    
+    func requestCheerMarket(marketName: String, address: String) async -> Result<Void, MarketRepositoryError> {
+        let result = await marketNetworkService.postMarketRequest(name: marketName, address: address)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            return .success(())
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+            
+        }
+    }
+    
+    func likeCheerMarket(marketId: Int) async -> Result<Void, MarketRepositoryError> {
+        let result = await cheerMarketNetworkService.postCheerMarket(tempMarketId: marketId)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            return .success(())
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+            
+        }
+    }
+    
+    func fetchMyCheerTicketCount() async -> Result<Int, MarketRepositoryError> {
+        let result = await memberNetworkService.fetchMemberInfo()
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let count = data.response.cheerTicket
+            return .success(count)
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+            
+        }
+    }
+    
+    private func processError(statusCode: Int) -> MarketRepositoryError {
+        switch statusCode {
+        case 200..<300:
+            return .decoding
+        default:
+            return .network
+        }
+    }
+}

--- a/MarketPlace/Data/Repositories/DefaultMarketRepository.swift
+++ b/MarketPlace/Data/Repositories/DefaultMarketRepository.swift
@@ -1,0 +1,155 @@
+//
+//  DefaultMarketRepository.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 3/8/26.
+//
+
+import Foundation
+
+final class DefaultMarketRepository {
+    private let marketNetworkService: MarketServiceProtocol
+    
+    init(marketNetworkService: MarketServiceProtocol) {
+        self.marketNetworkService = marketNetworkService
+    }
+}
+
+extension DefaultMarketRepository: MarketRepository {
+    func fetchMarketWithCategory(
+        category: MarketCategory,
+        lastPageIndex: Int?,
+        pageSize: Int?
+    ) async -> Result<[MarketListModel], MarketRepositoryError> {
+        
+        let result = await marketNetworkService.fetchMarketAll(lastPageIndex: lastPageIndex, category: category.toString(), pageSize: pageSize)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let markets = data.response.marketResDtos.map {
+                $0.toEntity()
+            }
+            
+            return .success(markets)
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+
+        }
+        
+    }
+    
+    func fetchMarketWithAddress(
+        category: MarketCategory,
+        lastPageIndex: Int?,
+        pageSize: Int?
+    ) async -> Result<[MarketListModel], MarketRepositoryError> {
+        
+        let result = await marketNetworkService.fetchMarketsWithAddress(lastPageIndex: lastPageIndex, category: category.toString(), pageSize: pageSize)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let markets = data.response.marketResDtos.map {
+                $0.toEntity()
+            }
+            
+            return .success(markets)
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+            
+        }
+    }
+    
+    func fetchMarketDetail(id: Int) async -> Result<MarketDetailModel, MarketRepositoryError> {
+        let result = await marketNetworkService.fetchMarketDetail(marketId: id)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let market = data.response.toEntity()
+            
+            return .success(market)
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+        }
+    }
+    
+    func fetchFavoriteMarkets(lastModifiedAt: String?, pageSize: Int?) async -> Result<[MarketListModel], MarketRepositoryError> {
+        let result = await marketNetworkService.fetchOwnFavoriteMarkets(lastModifiedAt: lastModifiedAt, pageSize: pageSize)
+                
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let markets = data.response.marketResDtos.map {
+                $0.toEntity()
+            }
+            
+            return .success(markets)
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+
+        }
+    }
+    
+    func saveFavoriteMarket(id: Int) async -> Result<Void, MarketRepositoryError> {
+        let result = await marketNetworkService.postFavoriteMarket(marketId: id)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            return .success(())
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+            
+        }
+    }
+    
+    func fetchMarketQueries(keyword: String, lastPageIndex: Int?, pageSize: Int?) async -> Result<[MarketListModel], MarketRepositoryError> {
+        let result = await marketNetworkService.fetchSearchMarketsList(lastPageIndex: lastPageIndex, pageSize: pageSize, name: keyword)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let markets = data.response.marketResDtos.map {
+                $0.toEntity()
+            }
+            
+            return .success(markets)
+            
+        case .failure(let statusCode, let message):
+            
+            return .failure(processError(statusCode: statusCode))
+            
+        }
+    }
+    
+    func saveMakretRecentQueries(keyword: String) async {
+        // 로컬 스토리지에 저장
+    }
+    
+    func fetchMarketRecentsQueries() async -> Result<[MarketListModel], MarketRepositoryError> {
+        // 로컬 스토리지에서 불러오기
+        
+        return .success([])
+    }
+    
+    private func processError(statusCode: Int) -> MarketRepositoryError {
+        switch statusCode {
+        case 200..<300:
+            return .decoding
+        default:
+            return .network
+        }
+    }
+}

--- a/MarketPlace/Domain/Entities/Market/CheerMarketModel.swift
+++ b/MarketPlace/Domain/Entities/Market/CheerMarketModel.swift
@@ -10,9 +10,9 @@ import Foundation
 struct CheerMarketModel: Identifiable {
     let id: Int
     let name: String
-    let description: String
+    let description: String?
     let thumbnail: String
-    let cheerCount: Int
-    let isCheer: String
-    let dueDate: Int
+    let cheerCount: Int?
+    let isCheer: Bool
+    let dueDate: Int?
 }

--- a/MarketPlace/Domain/Interface/Repository/CheerMarketRepository.swift
+++ b/MarketPlace/Domain/Interface/Repository/CheerMarketRepository.swift
@@ -1,0 +1,25 @@
+//
+//  CheerMarketRepository.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 3/8/26.
+//
+
+import Foundation
+
+
+
+protocol CheerMarketRepository {
+    
+    func fetchCheerMarketWithCategory(category: MarketCategory, lastPageIndex: Int?, page: Int?) async -> Result<[CheerMarketModel], MarketRepositoryError>
+    
+    func fetchMarketQueries(keyword: String, lastPageIndex: Int?, pageSize: Int?) async -> Result<[CheerMarketModel], MarketRepositoryError>
+    
+    func fetchUpcomingCheerMarket(lastPageIndex: Int, lastCheerCount: Int?, page: Int?) async -> Result<[CheerMarketModel], MarketRepositoryError>
+    
+    func requestCheerMarket(marketName: String, address: String) async -> Result<Void, MarketRepositoryError>
+    
+    func likeCheerMarket(marketId: Int) async -> Result<Void, MarketRepositoryError>
+    
+    func fetchMyCheerTicketCount() async -> Result<Int, MarketRepositoryError>
+}

--- a/MarketPlace/Domain/Interface/Repository/MarketRepository.swift
+++ b/MarketPlace/Domain/Interface/Repository/MarketRepository.swift
@@ -1,0 +1,34 @@
+//
+//  MarketRepository.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 3/8/26.
+//
+
+import Foundation
+
+enum MarketRepositoryError: Error {
+    case decoding
+    case network
+    case unknown
+}
+
+protocol MarketRepository {
+    
+    func fetchMarketWithCategory(category: MarketCategory, lastPageIndex: Int?, pageSize: Int?) async -> Result<[MarketListModel], MarketRepositoryError>
+    
+    func fetchMarketWithAddress(category: MarketCategory, lastPageIndex: Int?, pageSize: Int?) async -> Result<[MarketListModel], MarketRepositoryError>
+    
+    func fetchMarketDetail(id: Int) async -> Result<MarketDetailModel, MarketRepositoryError>
+    
+    func fetchFavoriteMarkets(lastModifiedAt: String?, pageSize: Int?) async -> Result<[MarketListModel], MarketRepositoryError>
+    
+    func saveFavoriteMarket(id: Int) async -> Result<Void, MarketRepositoryError>
+    
+    func fetchMarketQueries(keyword: String, lastPageIndex: Int?, pageSize: Int?) async -> Result<[MarketListModel], MarketRepositoryError>
+    
+    func saveMakretRecentQueries(keyword: String) async
+    
+    func fetchMarketRecentsQueries() async -> Result<[MarketListModel], MarketRepositoryError>
+    
+}


### PR DESCRIPTION
## ⭐️ Related Issue
- #140  

## 📝 Description
- 두가지 도메인(Market, CheerMarket)에 대해 각각 Repository 프로토콜을 추가
- 해당 protocol을 따르는 DefaultRepository 구현체를 추가하여 네트워크로 데이터를 받아오는 코드를 추가

 
<br>

**ex )**
``` swift 
protocol MarketRepository {}

final class DefaultMarketRepository: MarketRepository {}
```