### PR TITLE
[Feat] Auth, Member, Notification 도메인 Repository protocol 및 구현체를 추가합니다.

### DIFF
--- a/MarketPlace/Data/Repositories/DefaultAuthRepository.swift
+++ b/MarketPlace/Data/Repositories/DefaultAuthRepository.swift
@@ -1,0 +1,47 @@
+//
+//  DefaultAuthRepository.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 3/9/26.
+//
+
+import Foundation
+
+final class DefaultAuthRepository {
+    private let memberNetworkService: MemberServiceProtocol
+    
+    init(memberNetworkService: MemberServiceProtocol) {
+        self.memberNetworkService = memberNetworkService
+    }
+}
+
+extension DefaultAuthRepository: AuthRepository {
+    func login(studentId: String, password: String) async -> Result<String, AuthRepositoryError> {
+        let result = await memberNetworkService.signIn(studentId: studentId, password: password)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let token = data.response
+            
+            return .success(token)
+            
+        case .failure(let statusCode, let message):
+            switch statusCode {
+            case 200..<300:
+                return .failure(.decoding)
+            default:
+                return .failure(.network)
+            }
+        }
+    }
+    
+    func logout() -> Result<Void, AuthRepositoryError> {
+        KeychainManager.delete(KeyChainKeys.token)
+        KeychainManager.delete(KeyChainKeys.studentId)
+        KeychainManager.delete(KeyChainKeys.password)
+        UserDefaults.standard.set(false, forKey: UserDefaultsKeys.saveId)
+        
+        return .success(())
+    }
+}

--- a/MarketPlace/Data/Repositories/DefaultMemberRepository.swift
+++ b/MarketPlace/Data/Repositories/DefaultMemberRepository.swift
@@ -1,0 +1,38 @@
+//
+//  DefaultMemberRepository.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 3/9/26.
+//
+
+import Foundation
+
+final class DefaultMemberRepository {
+    private let memberNetworkService: MemberServiceProtocol
+    
+    init(memberNetworkService: MemberServiceProtocol) {
+        self.memberNetworkService = memberNetworkService
+    }
+}
+
+extension DefaultMemberRepository: MemberRepository {
+    func fetchStudentId() async -> Result<Int, MemberRepositoryError> {
+        let result = await memberNetworkService.fetchMemberInfo()
+        
+        switch result {
+        case .success(let data, let statusCode):
+            
+            let studentId = data.response.studentId
+            
+            return .success(studentId)
+            
+        case .failure(let statusCode, let message):
+            switch statusCode {
+            case 200..<300:
+                return .failure(.decoding)
+            default:
+                return .failure(.network)
+            }
+        }
+    }
+}

--- a/MarketPlace/Data/Repositories/DefaultNotificationRepository.swift
+++ b/MarketPlace/Data/Repositories/DefaultNotificationRepository.swift
@@ -1,0 +1,64 @@
+//
+//  DefaultNotificationRepository.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 3/9/26.
+//
+
+import Foundation
+
+final class DefaultNotificationRepository {
+    private let notificationNetworkService: NotificationServiceProtocol
+    
+    init(notificationNetworkService: NotificationServiceProtocol) {
+        self.notificationNetworkService = notificationNetworkService
+    }
+}
+
+extension DefaultNotificationRepository: NotificationRepository {
+    func fetchNotifications(type: String?, size: Int?) async -> Result<[NotificationModel], NotificationRepositoryError> {
+        let result = await notificationNetworkService.fetchNotifications(type: type, size: size)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            let notifications = data.response.notificationResList.map {
+                $0.toEntity()
+            }
+            
+            return .success(notifications)
+        case .failure(let statusCode, let message):
+            return .failure(processError(statusCode: statusCode))
+        }
+    }
+    
+    func readNotification(notificationId: Int) async -> Result<Void, NotificationRepositoryError> {
+        let result = await notificationNetworkService.patchNotification(notificationId: notificationId)
+        
+        switch result {
+        case .success(let data, let statusCode):
+            return .success(())
+        case .failure(let statusCode, let message):
+            return .failure(processError(statusCode: statusCode))
+        }
+    }
+    
+    func readNotificationsAll() async -> Result<Void, NotificationRepositoryError> {
+        let result = await notificationNetworkService.patchNotificationAll()
+        
+        switch result {
+        case .success(let data, let statusCode):
+            return .success(())
+        case .failure(let statusCode, let message):
+            return .failure(processError(statusCode: statusCode))
+        }
+    }
+    
+    private func processError(statusCode: Int) -> NotificationRepositoryError {
+        switch statusCode {
+        case 200..<300:
+            return .decoding
+        default:
+            return .network
+        }
+    }
+}

--- a/MarketPlace/Domain/Interface/Repository/AuthRepository.swift
+++ b/MarketPlace/Domain/Interface/Repository/AuthRepository.swift
@@ -1,0 +1,22 @@
+//
+//  AuthRepository.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 3/9/26.
+//
+
+import Foundation
+
+enum AuthRepositoryError: Error {
+    case decoding
+    case network
+    case unknown
+}
+
+protocol AuthRepository {
+    
+    func login(studentId: String, password: String) async -> Result<String, AuthRepositoryError>
+    
+    func logout() -> Result<Void, AuthRepositoryError>
+    
+}

--- a/MarketPlace/Domain/Interface/Repository/MemberRepository.swift
+++ b/MarketPlace/Domain/Interface/Repository/MemberRepository.swift
@@ -1,0 +1,20 @@
+//
+//  MemberRepository.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 3/9/26.
+//
+
+import Foundation
+
+enum MemberRepositoryError: Error {
+    case decoding
+    case network
+    case unknown
+}
+
+protocol MemberRepository {
+    
+    func fetchStudentId() async -> Result<Int, MemberRepositoryError>
+    
+}

--- a/MarketPlace/Domain/Interface/Repository/NotificationRepository.swift
+++ b/MarketPlace/Domain/Interface/Repository/NotificationRepository.swift
@@ -1,0 +1,24 @@
+//
+//  NotificationRepository.swift
+//  MarketPlace
+//
+//  Created by Bowon Han on 3/9/26.
+//
+
+import Foundation
+
+enum NotificationRepositoryError: Error {
+    case decoding
+    case network
+    case unknown
+}
+
+protocol NotificationRepository {
+    
+    func fetchNotifications(type: String?, size: Int?) async -> Result<[NotificationModel], NotificationRepositoryError>
+    
+    func readNotification(notificationId: Int) async -> Result<Void, NotificationRepositoryError>
+    
+    func readNotificationsAll() async -> Result<Void, NotificationRepositoryError>
+    
+}


### PR DESCRIPTION
## ⭐️ Related Issue
- #140 

## 📝 Description
- 각 도메인(Auth, Member, Notification)에 대해 Repository 프로토콜을 추가
- 해당 protocol을 따르는 DefaultRepository 구현체를 추가하여 네트워크로 데이터를 받아오는 코드를 추가

 
<br>

**ex )**
``` swift 
protocol CouponRepository {}

final class DefaultCouponRepository: CouponRepository {}
```